### PR TITLE
Spring release request

### DIFF
--- a/code/chef de cuisine.R
+++ b/code/chef de cuisine.R
@@ -8,88 +8,91 @@ library("ggplot2")
 library(mailR)
 rm(list = ls())
 # copying log over to the cloud
-file.copy("/home/rstudio/ShinyApps/dk/cdf.log",
-          "/home/rstudio/Dropbox/GTA cloud/17 Shiny/4 data kitchen/log/chef de cuisine.log",overwrite = T)
+file.copy("/home/rstudio/ShinyApps/data-dev/cdf.log",
+          "/home/rstudio/Dropbox/GTA cloud/0 dev/data-kitchen-pb/log/chef de cuisine.log",overwrite = T)
+
+# path = "17 Shiny/4 data kitchen/"
+path = "0 dev/data-kitchen-pb/"
 
 ## check if a process is running on the server
 running.processes=system("ps aux", intern=T)
 
-load("/home/rstudio/Dropbox/GTA cloud/17 Shiny/4 data kitchen/log/kitchen log.Rdata")
+load(paste0("/home/rstudio/Dropbox/GTA cloud/",path,"log/kitchen log.Rdata"))
 kitchen.busy=sum(as.numeric(grepl("(cdf.R)",running.processes, ignore.case = T)))
 if(kitchen.busy>2){
-
+  
   print(paste(Sys.time(), ": kitchen is busy with order #",min(kitchen.log$ticket.number[kitchen.log$under.preparation==1]), sep=""))
   print(running.processes[grepl("(cdf.R)",running.processes, ignore.case = T)])
-
+  
 } else{
-
-
+  
+  
   ## setup
   # setwd("C:/Users/jfrit/Desktop/Dropbox/GTA cloud/17 Shiny/4 data kitchen")
   # setwd("/Users/patrickbuess/Dropbox/Collaborations/GTA cloud")
   setwd("/home/rstudio/Dropbox/GTA cloud")
-  source("17 Shiny/4 data kitchen/code/order processing/kitchen utensils.R")
-  load("17 Shiny/4 data kitchen/log/kitchen log.Rdata")
-
-
-
+  source(paste0(path,"code/order processing/kitchen utensils.R"))
+  load(paste0(path,"log/kitchen log.Rdata"))
+  
+  
+  
   if(sum(kitchen.log$under.preparation)==0){
     print(paste(Sys.time(), ": no business", sep=""))
-
+    
   }else{
-
+    
     max.rnds=sum(kitchen.log$under.preparation)
     rnd=1
     ## if nothing is running, then start the oven.
     while(sum(kitchen.log$under.preparation)>0 & rnd<=max.rnds){
-
+      
       # first come, first served.
       log.row=min(which(kitchen.log$under.preparation==1))
-
-      logpath=paste("17 Shiny/4 data kitchen/results/",Sys.Date()," - GTA data dish #", kitchen.log$ticket.number[log.row],".txt",sep="")
+      
+      logpath=paste(path,"results/",Sys.Date()," - GTA data dish #", kitchen.log$ticket.number[log.row],".txt",sep="")
       con <- file(logpath)
       sink(con, append=T)
       sink(con, append=T, type="message")
-
+      
       ## Order: update GTA (clearing all outstanding update orders at once)
       if(kitchen.log$order.type[log.row]=="GTA"){
         kitchen.log$time.start[kitchen.log$order.type=="GTA" & kitchen.log$under.preparation==1]=Sys.time()
         class(kitchen.log$time.start)=c('POSIXt', 'POSIXct')
-        save(kitchen.log, file="17 Shiny/4 data kitchen/log/kitchen log.Rdata")
-
-        collection(source("17 Shiny/4 data kitchen/code/order processing/GTA data update - 1 - data download.R", echo=T, max.deparse.length=1000000, print.eval = T))
-        collection(source("17 Shiny/4 data kitchen/code/order processing/GTA data update - 2 - database assembly.R", echo=T, max.deparse.length=1000000, print.eval = T))
-        collection(source("17 Shiny/4 data kitchen/code/order processing/GTA data update - 3 - master plus.R", echo=T, max.deparse.length=1000000, print.eval = T))
-
-        load("17 Shiny/4 data kitchen/log/kitchen log.Rdata")
+        save(kitchen.log, file=paste0(path,"log/kitchen log.Rdata"))
+        
+        collection(source(paste0(path,"code/order processing/GTA data update - 1 - data download.R"), echo=T, max.deparse.length=1000000, print.eval = T))
+        collection(source(paste0(path,"code/order processing/GTA data update - 2 - database assembly.R"), echo=T, max.deparse.length=1000000, print.eval = T))
+        collection(source(paste0(path,"code/order processing/GTA data update - 3 - master plus.R"), echo=T, max.deparse.length=1000000, print.eval = T))
+        
+        load(paste0(path,"log/kitchen log.Rdata"))
         kitchen.log$time.finish[kitchen.log$order.type=="GTA" & kitchen.log$under.preparation==1]=Sys.time()
         class(kitchen.log$time.finish)=c('POSIXt', 'POSIXct')
         kitchen.log$under.preparation[kitchen.log$order.type=="GTA" & kitchen.log$under.preparation==1]=0
       }
-
-
-
+      
+      
+      
       ## Order: trade share
       if(kitchen.log$order.type[log.row]=="trade coverage"){
         kitchen.log$time.start[log.row]=Sys.time()
         class(kitchen.log$time.start)=c('POSIXt', 'POSIXct')
-        save(kitchen.log, file="17 Shiny/4 data kitchen/log/kitchen log.Rdata")
+        save(kitchen.log, file=paste0(path,"log/kitchen log.Rdata"))
         ## extracting parameters
         kl=kitchen.log[log.row,]
-
-        collection(source("17 Shiny/4 data kitchen/code/order processing/GTA data kitchen order - trade coverage.R", echo=T, max.deparse.length=1000000, print.eval = T))
-
+        
+        collection(source(paste0(path,"code/order processing/GTA data kitchen order - trade coverage.R"), echo=T, max.deparse.length=1000000, print.eval = T))
+        
         if (error.message[1] == T) {
-
+          
           ## Sending error email.
           library(mailR)
           sender = "data@globaltradealert.org"
           recipients = as.character(kitchen.log$order.email[log.row])
-
+          
           sbjct=paste("Your order could not be processed [GTA data dish #",kitchen.log$ticket.number[log.row],"][",kitchen.log$order.name[log.row],"]",sep="")
-
+          
           message=paste0("Hello \n\nThank you for your order. Your order encountered an error and could not be processed. \nThe error message was: ",error.message[2]," \n\nIn case of questions or suggestions, please reply to this message. \n\nRegards \nGlobal Trade Alert Data")
-
+          
           send.mail(from = sender,
                     to = recipients,
                     subject=sbjct,
@@ -102,7 +105,7 @@ if(kitchen.busy>2){
                                 passwd="B0d@nstrasse",
                                 tls=T),
                     authenticate = T)
-
+          
           send.mail(from = sender,
                     to = c("patrick.buess@student.unisg.ch","fritz.johannes@gmail.com"),
                     subject=paste0("[ERROR Data Kitchen]: ",sbjct),
@@ -115,176 +118,48 @@ if(kitchen.busy>2){
                                 passwd="B0d@nstrasse",
                                 tls=T),
                     authenticate = T)
-
+          
           ## updating log
-          load("17 Shiny/4 data kitchen/log/kitchen log.Rdata")
+          load(paste0(path,"log/kitchen log.Rdata"))
           kitchen.log$time.finish[log.row]=Sys.time()
           class(kitchen.log$time.finish)=c('POSIXt', 'POSIXct')
           kitchen.log$under.preparation[log.row]=0
-
+          
           rm(recipients, message, sbjct, sender)
-
-
+          
+          
         }
-
+        
         if (error.message[1]==F) {
-
+          
           ## rename trade coverage file
-          result.path=paste("17 Shiny/4 data kitchen/results/",Sys.Date()," - GTA data dish #", kitchen.log$ticket.number[log.row],".xlsx", sep="")
-          file.rename(paste("17 Shiny/4 data kitchen/results/GTA trade coverage estimates from ", Sys.Date(),".xlsx", sep=""),result.path)
-
-
+          result.path=paste(path,"results/",Sys.Date()," - GTA data dish #", kitchen.log$ticket.number[log.row],".xlsx", sep="")
+          # file.rename(paste(path,"results/GTA trade coverage estimates from ", Sys.Date(),".xlsx", sep=""),result.path)
+          attachments <- c(result.path)
+          
+          ## attach interventions list if necessary
+          if (kitchen.log$xlsx.interventions[log.row]) {
+            results.path.interventions=paste(path,"results/",Sys.Date()," - GTA data dish #", kitchen.log$ticket.number[log.row]," - interventions.xlsx", sep="")
+            # file.rename(paste(path,"results/GTA trade coverage interventions from ", Sys.Date(),".xlsx", sep=""),result.path)
+            attachments <- c(attachments, results.path.interventions)
+            
+          }
+          
           ## updating log
-          load("17 Shiny/4 data kitchen/log/kitchen log.Rdata")
+          load(paste0(path,"log/kitchen log.Rdata"))
           kitchen.log$time.finish[log.row]=Sys.time()
           class(kitchen.log$time.finish)=c('POSIXt', 'POSIXct')
           kitchen.log$under.preparation[log.row]=0
-
-
+          
+          
           ## Serving a fresh data dish.
           library(mailR)
           sender = "data@globaltradealert.org"
           recipients = as.character(kitchen.log$order.email[log.row])
           sbjct=paste("Your data is ready [GTA data dish #",kitchen.log$ticket.number[log.row],"][",kitchen.log$order.name[log.row],"]",sep="")
           message="Hello \n\nThank you for your order. Please find the requested GTA data in the attached Excel file. \n\nIn case of questions or suggestions, please reply to this message. \n\nRegards\nGlobal Trade Alert Data"
-
-
-          send.mail(from = sender,
-                    to = recipients,
-                    subject=sbjct,
-                    body=message,
-                    html=F,
-                    attach.files = result.path,
-                    smtp = list(host.name = "mail.infomaniak.com",
-                                port=587,
-                                user.name=sender,
-                                passwd="B0d@nstrasse",
-                                tls=T),
-                    authenticate = T)
-
-          rm(recipients, message, sbjct, sender, result.path)
-
-        }
-      }
-
-
-
-      ## Order: Count statistics
-      if(kitchen.log$order.type[log.row]=="count statistics"){
-        kitchen.log$time.start[log.row]=Sys.time()
-        class(kitchen.log$time.start)=c('POSIXt', 'POSIXct')
-        save(kitchen.log, file="17 Shiny/4 data kitchen/log/kitchen log.Rdata")
-        ## extracting parameters
-        kl=kitchen.log[log.row,]
-
-        source("17 Shiny/4 data kitchen/code/order processing/GTA data kitchen order - count statistics.R", echo=T, max.deparse.length=1000000, print.eval = T)
-
-        if (error.message[1] == T) {
-
-          ## Sending error email.
-          library(mailR)
-          sender = "data@globaltradealert.org"
-          recipients = as.character(kitchen.log$order.email[log.row])
-
-          sbjct=paste("Your order could not be processed [GTA data dish #",kitchen.log$ticket.number[log.row],"][",kitchen.log$order.name[log.row],"]",sep="")
-
-          message=paste0("Hello \n\nThank you for your order. Your order encountered an error and could not be processed. \nThe error message was: ",error.message[2]," \n\nIn case of questions or suggestions, please reply to this message.\n\nRegards\nGlobal Trade Alert Data")
-
-          send.mail(from = sender,
-                    to = recipients,
-                    subject=sbjct,
-                    body=message,
-                    html=F,
-                    # attach.files = attachments,
-                    smtp = list(host.name = "mail.infomaniak.com",
-                                port=587,
-                                user.name=sender,
-                                passwd="B0d@nstrasse",
-                                tls=T),
-                    authenticate = T)
-
-          send.mail(from = sender,
-                    to = c("patrick.buess@student.unisg.ch","fritz.johannes@gmail.com"),
-                    subject=paste0("[ERROR Data Kitchen]: ",sbjct),
-                    body=message,
-                    html=F,
-                    # attach.files = attachments,
-                    smtp = list(host.name = "mail.infomaniak.com",
-                                port=587,
-                                user.name=sender,
-                                passwd="B0d@nstrasse",
-                                tls=T),
-                    authenticate = T)
-
-          ## updating log
-          load("17 Shiny/4 data kitchen/log/kitchen log.Rdata")
-          kitchen.log$time.finish[log.row]=Sys.time()
-          class(kitchen.log$time.finish)=c('POSIXt', 'POSIXct')
-          kitchen.log$under.preparation[log.row]=0
-
-          rm(recipients, message, sbjct, sender)
-
-
-        }
-
-        if (error.message[1]==F) {
-
-          attachments <- c()
-
-          ## rename data count xlsx file
-          if (kl$xlsx == T) {
-            result.path.xlsx=paste("17 Shiny/4 data kitchen/results/",Sys.Date()," - GTA data dish #", kitchen.log$ticket.number[log.row],".xlsx", sep="")
-            file.rename(paste("17 Shiny/4 data kitchen/results/Count statistics from ", Sys.Date(),".xlsx", sep=""),result.path.xlsx)
-            attachments <- c(attachments, result.path.xlsx)
-
-          }
-
-
-          ## rename count stat map
-          if (kl$map == T) {
-            result.path.map=paste("17 Shiny/4 data kitchen/results/",Sys.Date()," - GTA map #", kitchen.log$ticket.number[log.row],".png", sep="")
-            file.rename(paste("17 Shiny/4 data kitchen/results/Map chart from ", Sys.Date(),".png", sep=""),result.path.map)
-            attachments <- c(attachments, result.path.map)
-
-          }
-
-          ## rename count stat tile
-          if (kl$tile == T) {
-            result.path.tile=paste("17 Shiny/4 data kitchen/results/",Sys.Date()," - GTA tile #", kitchen.log$ticket.number[log.row],".png", sep="")
-            file.rename(paste("17 Shiny/4 data kitchen/results/Tile chart from ", Sys.Date(),".png", sep=""),result.path.tile)
-            attachments <- c(attachments, result.path.tile)
-
-          }
-
-          ## rename count stat line
-          if (kl$line == T) {
-            result.path.line=paste("17 Shiny/4 data kitchen/results/",Sys.Date()," - GTA line #", kitchen.log$ticket.number[log.row],".png", sep="")
-            file.rename(paste("17 Shiny/4 data kitchen/results/Line chart from ", Sys.Date(),".png", sep=""),result.path.line)
-            attachments <- c(attachments, result.path.line)
-          }
-
-          ## rename count stat bar
-          if (kl$bar == T) {
-            result.path.bar=paste("17 Shiny/4 data kitchen/results/",Sys.Date()," - GTA bar #", kitchen.log$ticket.number[log.row],".png", sep="")
-            file.rename(paste("17 Shiny/4 data kitchen/results/Bar chart from ", Sys.Date(),".png", sep=""),result.path.bar)
-            attachments <- c(attachments, result.path.bar)
-          }
-
-          ## rename count interventions list
-          if (kl$interventions.list == T) {
-            result.path.list=paste("17 Shiny/4 data kitchen/results/",Sys.Date()," -  GTA data dish # ", kitchen.log$ticket.number[log.row]," - list of interventions & parameter choices.xlsx", sep="")
-            file.rename(paste("17 Shiny/4 data kitchen/results/Interventions list from ", Sys.Date(),".xlsx", sep=""),result.path.list)
-            attachments <- c(attachments, result.path.list)
-          }
-
-
-          ## Serving a fresh data dish.
-          sender = "data@globaltradealert.org"
-          recipients = as.character(kitchen.log$order.email[log.row])
-          sbjct=paste("Your data is ready [GTA data dish #",kitchen.log$ticket.number[log.row],"][",kitchen.log$order.name[log.row],"]",sep="")
-          message="Hello \n\nThank you for your order. Please find the requested GTA data in the attached Excel file.\n\nIn case of questions or suggestions, please reply to this message.\n\nRegards\nGlobal Trade Alert Data"
-
-
+          
+          
           send.mail(from = sender,
                     to = recipients,
                     subject=sbjct,
@@ -297,29 +172,165 @@ if(kitchen.busy>2){
                                 passwd="B0d@nstrasse",
                                 tls=T),
                     authenticate = T)
-
+          
+          rm(recipients, message, sbjct, sender, attachments)
+          
+        }
+      }
+      
+      
+      
+      ## Order: Count statistics
+      if(kitchen.log$order.type[log.row]=="count statistics"){
+        kitchen.log$time.start[log.row]=Sys.time()
+        class(kitchen.log$time.start)=c('POSIXt', 'POSIXct')
+        save(kitchen.log, file=paste0(path,"log/kitchen log.Rdata"))
+        ## extracting parameters
+        kl=kitchen.log[log.row,]
+        
+        source(paste0(path,"code/order processing/GTA data kitchen order - count statistics.R"), echo=T, max.deparse.length=1000000, print.eval = T)
+        
+        if (error.message[1] == T) {
+          
+          ## Sending error email.
+          library(mailR)
+          sender = "data@globaltradealert.org"
+          recipients = as.character(kitchen.log$order.email[log.row])
+          
+          sbjct=paste("Your order could not be processed [GTA data dish #",kitchen.log$ticket.number[log.row],"][",kitchen.log$order.name[log.row],"]",sep="")
+          
+          message=paste0("Hello \n\nThank you for your order. Your order encountered an error and could not be processed. \nThe error message was: ",error.message[2]," \n\nIn case of questions or suggestions, please reply to this message.\n\nRegards\nGlobal Trade Alert Data")
+          
+          send.mail(from = sender,
+                    to = recipients,
+                    subject=sbjct,
+                    body=message,
+                    html=F,
+                    # attach.files = attachments,
+                    smtp = list(host.name = "mail.infomaniak.com",
+                                port=587,
+                                user.name=sender,
+                                passwd="B0d@nstrasse",
+                                tls=T),
+                    authenticate = T)
+          
+          send.mail(from = sender,
+                    to = c("patrick.buess@student.unisg.ch","fritz.johannes@gmail.com"),
+                    subject=paste0("[ERROR Data Kitchen]: ",sbjct),
+                    body=message,
+                    html=F,
+                    # attach.files = attachments,
+                    smtp = list(host.name = "mail.infomaniak.com",
+                                port=587,
+                                user.name=sender,
+                                passwd="B0d@nstrasse",
+                                tls=T),
+                    authenticate = T)
+          
           ## updating log
-          load("17 Shiny/4 data kitchen/log/kitchen log.Rdata")
+          load(paste0(path,"log/kitchen log.Rdata"))
           kitchen.log$time.finish[log.row]=Sys.time()
           class(kitchen.log$time.finish)=c('POSIXt', 'POSIXct')
           kitchen.log$under.preparation[log.row]=0
-
-          rm(recipients, message, sbjct, sender, attachments)
-
+          
+          rm(recipients, message, sbjct, sender)
+          
+          
         }
-
+        
+        if (error.message[1]==F) {
+          
+          attachments <- c()
+          
+          ## rename data count xlsx file
+          if (kl$xlsx == T) {
+            result.path.xlsx=paste(path,"results/",Sys.Date()," - GTA data dish #", kitchen.log$ticket.number[log.row],".xlsx", sep="")
+            file.rename(paste(path,"results/Count statistics from ", Sys.Date(),".xlsx", sep=""),result.path.xlsx)
+            attachments <- c(attachments, result.path.xlsx)
+            
+          }
+          
+          
+          ## rename count stat map
+          if (kl$map == T) {
+            result.path.map=paste(path,"results/",Sys.Date()," - GTA map #", kitchen.log$ticket.number[log.row],".png", sep="")
+            file.rename(paste(path,"results/Map chart from ", Sys.Date(),".png", sep=""),result.path.map)
+            attachments <- c(attachments, result.path.map)
+            
+          }
+          
+          ## rename count stat tile
+          if (kl$tile == T) {
+            result.path.tile=paste(path,"results/",Sys.Date()," - GTA tile #", kitchen.log$ticket.number[log.row],".png", sep="")
+            file.rename(paste(path,"results/Tile chart from ", Sys.Date(),".png", sep=""),result.path.tile)
+            attachments <- c(attachments, result.path.tile)
+            
+          }
+          
+          ## rename count stat line
+          if (kl$line == T) {
+            result.path.line=paste(path,"results/",Sys.Date()," - GTA line #", kitchen.log$ticket.number[log.row],".png", sep="")
+            file.rename(paste(path,"results/Line chart from ", Sys.Date(),".png", sep=""),result.path.line)
+            attachments <- c(attachments, result.path.line)
+          }
+          
+          ## rename count stat bar
+          if (kl$bar == T) {
+            result.path.bar=paste(path,"results/",Sys.Date()," - GTA bar #", kitchen.log$ticket.number[log.row],".png", sep="")
+            file.rename(paste(path,"results/Bar chart from ", Sys.Date(),".png", sep=""),result.path.bar)
+            attachments <- c(attachments, result.path.bar)
+          }
+          
+          ## rename count interventions list
+          if (kl$interventions.list == T) {
+            result.path.list=paste(path,"results/",Sys.Date()," -  GTA data dish # ", kitchen.log$ticket.number[log.row]," - list of interventions & parameter choices.xlsx", sep="")
+            file.rename(paste(path,"results/Interventions list from ", Sys.Date(),".xlsx", sep=""),result.path.list)
+            attachments <- c(attachments, result.path.list)
+          }
+          
+          
+          ## Serving a fresh data dish.
+          sender = "data@globaltradealert.org"
+          recipients = as.character(kitchen.log$order.email[log.row])
+          sbjct=paste("Your data is ready [GTA data dish #",kitchen.log$ticket.number[log.row],"][",kitchen.log$order.name[log.row],"]",sep="")
+          message="Hello \n\nThank you for your order. Please find the requested GTA data in the attached Excel file.\n\nIn case of questions or suggestions, please reply to this message.\n\nRegards\nGlobal Trade Alert Data"
+          
+          
+          send.mail(from = sender,
+                    to = recipients,
+                    subject=sbjct,
+                    body=message,
+                    html=F,
+                    attach.files = attachments,
+                    smtp = list(host.name = "mail.infomaniak.com",
+                                port=587,
+                                user.name=sender,
+                                passwd="B0d@nstrasse",
+                                tls=T),
+                    authenticate = T)
+          
+          ## updating log
+          load(paste0(path,"log/kitchen log.Rdata"))
+          kitchen.log$time.finish[log.row]=Sys.time()
+          class(kitchen.log$time.finish)=c('POSIXt', 'POSIXct')
+          kitchen.log$under.preparation[log.row]=0
+          
+          rm(recipients, message, sbjct, sender, attachments)
+          
+        }
+        
       }
-
+      
       ## Storing updated log
-      save(kitchen.log, file = "17 Shiny/4 data kitchen/log/kitchen log.Rdata")
-      load("17 Shiny/4 data kitchen/log/kitchen log.Rdata")
+      save(kitchen.log, file = paste0(path,"log/kitchen log.Rdata"))
+      load(paste0(path,"log/kitchen log.Rdata"))
       sink()
       sink(type="message")
       rnd=rnd+1
     }
   }
-
-
+  
+  
 }
 
 

--- a/code/modules/updateCoverages.R
+++ b/code/modules/updateCoverages.R
@@ -1,35 +1,35 @@
 callUpdateCoverages <- function(session,
                                 query = NULL) {
-
-
+  
+  
   if (is.null(query)==F) {
-
+    
     if (query == "Unset") {
       updateCoverages(session = session)
-      }
-
-
+    }
+    
+    
     if (query == "query_1") {
-
+      
       updateCoverages(session = session)
-
+      
       updateCoverages(session = session,
                       gta.evaluation = c("Red","Amber"),
                       importers = c("United States of America","China"),
                       exporters = c("G20"))
     }
-
+    
   }
-
+  
 }
 
 
 updateCoverages <- function(session,
                             gta.evaluation = "",
                             affected.flows = "",
-                            implementers = "",
+                            implementers = "all",
                             keep.implementer = TRUE,
-                            affected = "",
+                            affected = "all",
                             keep.affected = TRUE,
                             keep.others = TRUE,
                             in.force.today = "Any",
@@ -39,39 +39,39 @@ updateCoverages <- function(session,
                             revocation.period = c(NA,NA),
                             keep.revocation.na = TRUE,
                             submission.period = c(NA,NA),
-                            intervention.types = "",
+                            intervention.types = "all",
                             keep.type = TRUE,
-                            mast.chapters = "",
+                            mast.chapters = "all",
                             keep.mast = TRUE,
                             implementation.level = "any",
                             keep.level = TRUE,
                             eligible.firms = "any",
                             keep.firms = TRUE,
-                            cpc.sectors = "",
+                            cpc.sectors = "all",
                             keep.cpc = TRUE,
-                            hs.codes = "",
+                            hs.codes = "all",
                             keep.hs = TRUE,
                             intervention.ids = "",
                             keep.interventions = TRUE,
                             lag.adjustment = NA,
                             coverage.period = "",
                             current.year.todate = c(2009, year(Sys.Date())),
-                            choose.tradebase = "base.years",
+                            choose.tradebase = "base",
                             choose.output = "share",
                             adjust.for.intra = TRUE,
-                            exporters = "",
+                            exporters = "all",
                             group.exporters = TRUE,
                             keep.exporters = TRUE,
                             incl.exporters.strictness = "ONEPLUS",
-                            nr.exporter = "",
-                            nr.exporter.incl = "ALL",
+                            nr.exporters = "",
+                            nr.exporters.incl = "ALL",
                             separate.exporter.groups = FALSE,
-                            importers = "",
+                            importers = "all",
                             group.importers = TRUE,
                             keep.importers = TRUE,
                             incl.importers.strictness = "ONEPLUS",
-                            nr.importer = "",
-                            nr.importer.incl = "ALL",
+                            nr.importers = "",
+                            nr.importers.incl = "ALL",
                             separate.importer.groups = FALSE,
                             implementer.role = c("Importer", "3rd country"),
                             nr.also.importers = "",
@@ -81,250 +81,250 @@ updateCoverages <- function(session,
                             hit.brackets = "",
                             group.type = TRUE,
                             group.mast = TRUE
-
-                            ) {
-
-
-    updateSelectInput(session,
-                      "gta.evaluation",
-                      selected = gta.evaluation)
-
-    updateSelectInput(session,
-                      "affected.flows",
-                      selected = affected.flows)
-
-    updateMultiInput(session,
-                     "implementers",
-                     selected = implementers)
-
-    updateCheckboxInput(session,
-                        "keep.implementer",
-                        value = keep.implementer)
-
-    updateMultiInput(session,
-                     "affected",
-                     selected = affected)
-
-    updateCheckboxInput(session,
-                        "keep.affected",
-                        value = keep.affected)
-
-    updateCheckboxInput(session,
-                        "keep.others",
-                        value = keep.others)
-
-    updateCheckboxInput(session,
-                        "in.force.today",
-                        value = in.force.today)
-
-    updateDateRangeInput(session,
-                         "announcement.period",
-                         start = announcement.period[1],
-                         end = announcement.period[2])
-
-    updateDateRangeInput(session,
-                         "implementation.period",
-                         start = implementation.period[1],
-                         end = implementation.period[2])
-
-    updateDateRangeInput(session,
-                         "revocation.period",
-                         start = revocation.period[1],
-                         end = revocation.period[2])
-
-
-    updateDateRangeInput(session,
-                         "submission.period",
-                         start = submission.period[1],
-                         end = submission.period[2])
-
-    updateMultiInput(session,
-                     "intervention.types",
-                     selected = intervention.types)
-
-    updateMultiInput(session,
-                     "intervention.types",
-                     selected = intervention.types)
-
-    updateCheckboxInput(session,
-                        "keep.type",
-                        value = keep.type)
-
-    updateMultiInput(session,
-                     "mast.chapters",
-                     selected = mast.chapters)
-
-    updateCheckboxInput(session,
-                        "keep.mast",
-                        value = keep.mast)
-
-    updateMultiInput(session,
-                     "implementation.level",
-                     selected = implementation.level)
-
-    updateCheckboxInput(session,
-                        "keep.level",
-                        value = keep.level)
-
-    updateMultiInput(session,
-                     "eligible.firms",
-                     selected = eligible.firms)
-
-    updateCheckboxInput(session,
-                        "keep.firms",
-                        value = keep.firms)
-
-    updateMultiInput(session,
-                     "cpc.sectors",
-                     selected = cpc.sectors)
-
-    updateCheckboxInput(session,
-                        "keep.cpc",
-                        value = keep.cpc)
-
-    updateMultiInput(session,
-                     "hs.codes",
-                     selected = hs.codes)
-
-
-    updateCheckboxInput(session,
-                        "keep.hs",
-                        value = keep.hs)
-
-    updateTextInput(session,
-                    "intervention.ids",
-                    value = intervention.ids)
-
-    updateCheckboxInput(session,
-                        "keep.interventions",
-                        value = keep.interventions)
-
-    updateDateInput(session,
-                    "lag.adjustment",
-                    value = lag.adjustment)
-
-
-
-    updateSliderInput(session,
-                      "coverage.period",
-                      value = coverage.period)
-
-
-    updateCheckboxInput(session,
-                        "current.year.todate",
-                        value = current.year.todate)
-
-
-    updateSelectInput(session,
-                      "choose.tradebase",
-                      selected = choose.tradebase)
-
-    updateSelectInput(session,
-                      "choose.output",
-                      selected = choose.output)
-
-    updateCheckboxInput(session,
-                        "adjust.for.intra",
-                        value = adjust.for.intra)
-
-    updateMultiInput(session,
-                     "exporters",
-                     selected = exporters)
-
-    updateCheckboxInput(session,
-                        "group.exporters",
-                        value = group.exporters)
-
-
-    updateCheckboxInput(session,
-                        "keep.exporters",
-                        value = keep.exporters)
-
-    
-    updateSelectInput(session,
-                      "incl.exporters.strictness",
-                      value = incl.exporters.strictness)
-    
-    updateTextInput(session,
-                    "nr.exporters",
-                    value = nr.exporters)
-    
-    updateSelectInput(session,
-                      "nr.exporters.incl",
-                      value = nr.exporters.incl)
-    
-
-    updateCheckboxInput(session,
-                        "separate.exporter.groups",
-                        value = separate.exporter.groups)
-
-
-    updateMultiInput(session,
-                     "importers",
-                     selected = importers)
-
-    updateCheckboxInput(session,
-                        "group.importers",
-                        value = group.importers)
-
-
-    updateCheckboxInput(session,
-                        "keep.importers",
-                        value = keep.importers)
-    
-    updateSelectInput(session,
-                      "incl.importers.strictness",
-                      value = incl.importers.strictness)
-    
-    updateTimtInput(session,
-                    "nr.importers",
-                    value = nr.importers)
-    
-    updateSelectInput(session,
-                      "nr.importers.incl",
-                      value = nr.importers.incl)
-
-
-    updateCheckboxInput(session,
-                        "separate.importer.groups",
-                        value = separate.importer.groups)
-
-
-    updateCheckboxGroupInput(session,
-                             "implementer.role",
-                             selected = implementer.role)
-
-    updateNumericInput(session,
-                       "nr.also.importers",
-                       value = nr.also.importers)
-
-
-    updateCheckboxInput(session,
-                        "jointly.affected.importers",
-                        value = jointly.affected.importers)
-
-    updateNumericInput(session,
-                       "nr.also.exporters",
-                       value = nr.also.exporters)
-
-
-    updateCheckboxInput(session,
-                        "jointly.affected.exporters",
-                        value = jointly.affected.exporters)
-
-    updateTextInput(session,
-                    "hit.brackets",
-                    value = hit.brackets)
-
-
-    updateCheckboxInput(session,
-                        "group.type",
-                        value = group.type)
-
-
-    updateCheckboxInput(session,
-                        "group.mast",
-                        value = group.mast)
-
-
+                            
+) {
+  
+  
+  updateSelectInput(session,
+                    "gta.evaluation",
+                    selected = gta.evaluation)
+  
+  updateSelectInput(session,
+                    "affected.flows",
+                    selected = affected.flows)
+  
+  updateMultiInput(session,
+                   "implementers",
+                   selected = implementers)
+  
+  updateCheckboxInput(session,
+                      "keep.implementer",
+                      value = keep.implementer)
+  
+  updateMultiInput(session,
+                   "affected",
+                   selected = affected)
+  
+  updateCheckboxInput(session,
+                      "keep.affected",
+                      value = keep.affected)
+  
+  updateCheckboxInput(session,
+                      "keep.others",
+                      value = keep.others)
+  
+  updateCheckboxInput(session,
+                      "in.force.today",
+                      value = in.force.today)
+  
+  updateDateRangeInput(session,
+                       "announcement.period",
+                       start = announcement.period[1],
+                       end = announcement.period[2])
+  
+  updateDateRangeInput(session,
+                       "implementation.period",
+                       start = implementation.period[1],
+                       end = implementation.period[2])
+  
+  updateDateRangeInput(session,
+                       "revocation.period",
+                       start = revocation.period[1],
+                       end = revocation.period[2])
+  
+  
+  updateDateRangeInput(session,
+                       "submission.period",
+                       start = submission.period[1],
+                       end = submission.period[2])
+  
+  updateMultiInput(session,
+                   "intervention.types",
+                   selected = intervention.types)
+  
+  updateMultiInput(session,
+                   "intervention.types",
+                   selected = intervention.types)
+  
+  updateCheckboxInput(session,
+                      "keep.type",
+                      value = keep.type)
+  
+  updateMultiInput(session,
+                   "mast.chapters",
+                   selected = mast.chapters)
+  
+  updateCheckboxInput(session,
+                      "keep.mast",
+                      value = keep.mast)
+  
+  updateMultiInput(session,
+                   "implementation.level",
+                   selected = implementation.level)
+  
+  updateCheckboxInput(session,
+                      "keep.level",
+                      value = keep.level)
+  
+  updateMultiInput(session,
+                   "eligible.firms",
+                   selected = eligible.firms)
+  
+  updateCheckboxInput(session,
+                      "keep.firms",
+                      value = keep.firms)
+  
+  updateMultiInput(session,
+                   "cpc.sectors",
+                   selected = cpc.sectors)
+  
+  updateCheckboxInput(session,
+                      "keep.cpc",
+                      value = keep.cpc)
+  
+  updateMultiInput(session,
+                   "hs.codes",
+                   selected = hs.codes)
+  
+  
+  updateCheckboxInput(session,
+                      "keep.hs",
+                      value = keep.hs)
+  
+  updateTextInput(session,
+                  "intervention.ids",
+                  value = intervention.ids)
+  
+  updateCheckboxInput(session,
+                      "keep.interventions",
+                      value = keep.interventions)
+  
+  updateDateInput(session,
+                  "lag.adjustment",
+                  value = lag.adjustment)
+  
+  
+  
+  updateSliderInput(session,
+                    "coverage.period",
+                    value = coverage.period)
+  
+  
+  updateCheckboxInput(session,
+                      "current.year.todate",
+                      value = current.year.todate)
+  
+  
+  updateSelectInput(session,
+                    "choose.tradebase",
+                    selected = choose.tradebase)
+  
+  updateSelectInput(session,
+                    "choose.output",
+                    selected = choose.output)
+  
+  updateCheckboxInput(session,
+                      "adjust.for.intra",
+                      value = adjust.for.intra)
+  
+  updateMultiInput(session,
+                   "exporters",
+                   selected = exporters)
+  
+  updateCheckboxInput(session,
+                      "group.exporters",
+                      value = group.exporters)
+  
+  
+  updateCheckboxInput(session,
+                      "keep.exporters",
+                      value = keep.exporters)
+  
+  
+  updateSelectInput(session,
+                    "incl.exporters.strictness",
+                    selected = incl.exporters.strictness)
+  
+  updateTextInput(session,
+                  "nr.exporters",
+                  value = nr.exporters)
+  
+  updateSelectInput(session,
+                    "nr.exporters.incl",
+                    selected = nr.exporters.incl)
+  
+  
+  updateCheckboxInput(session,
+                      "separate.exporter.groups",
+                      value = separate.exporter.groups)
+  
+  
+  updateMultiInput(session,
+                   "importers",
+                   selected = importers)
+  
+  updateCheckboxInput(session,
+                      "group.importers",
+                      value = group.importers)
+  
+  
+  updateCheckboxInput(session,
+                      "keep.importers",
+                      value = keep.importers)
+  
+  updateSelectInput(session,
+                    "incl.importers.strictness",
+                    selected = incl.importers.strictness)
+  
+  updateTextInput(session,
+                  "nr.importers",
+                  value = nr.importers)
+  
+  updateSelectInput(session,
+                    "nr.importers.incl",
+                    selected = nr.importers.incl)
+  
+  
+  updateCheckboxInput(session,
+                      "separate.importer.groups",
+                      value = separate.importer.groups)
+  
+  
+  updateCheckboxGroupInput(session,
+                           "implementer.role",
+                           selected = implementer.role)
+  
+  updateNumericInput(session,
+                     "nr.also.importers",
+                     value = nr.also.importers)
+  
+  
+  updateCheckboxInput(session,
+                      "jointly.affected.importers",
+                      value = jointly.affected.importers)
+  
+  updateNumericInput(session,
+                     "nr.also.exporters",
+                     value = nr.also.exporters)
+  
+  
+  updateCheckboxInput(session,
+                      "jointly.affected.exporters",
+                      value = jointly.affected.exporters)
+  
+  updateTextInput(session,
+                  "hit.brackets",
+                  value = hit.brackets)
+  
+  
+  updateCheckboxInput(session,
+                      "group.type",
+                      value = group.type)
+  
+  
+  updateCheckboxInput(session,
+                      "group.mast",
+                      value = group.mast)
+  
+  
 }

--- a/code/modules/updateDataCounts.R
+++ b/code/modules/updateDataCounts.R
@@ -1,25 +1,25 @@
 callUpdateDataCounts <- function(session,
                                  query = NULL) {
-
-
+  
+  
   if (is.null(query)==F) {
-
+    
     if (query == "Unset") {
-
+      
       updateDataCounts(session = session)
     }
-
+    
     if (query == "query_1") {
-
+      
       updateDataCounts(session = session)
       updateDataCounts(session = session,
                        gta.evaluation.data.count = c("Red","Amber"),
                        implementers.data.count = c("United States of America","China"),
                        affected.data.count = c("G20"))
     }
-
+    
   }
-
+  
 }
 
 
@@ -27,13 +27,13 @@ callUpdateDataCounts <- function(session,
 updateDataCounts <- function(session,
                              gta.evaluation.data.count = "",
                              affected.flows.data.count = "",
-                             implementers.data.count = "",
+                             implementers.data.count = "all",
                              keep.implementer.data.count = TRUE,
                              group.implementer.data.count = TRUE,
-                             affected.data.count = "",
+                             affected.data.count = "all",
                              keep.affected.data.count = TRUE,
                              group.affected.data.count = TRUE,
-                             keep.others.data.count = TRUE,
+                             keep.others.data.count = FALSE,
                              incl.affected.strictness.data.count = "ONEPLUS",
                              nr.affected.data.count = "",
                              nr.affected.incl.data.count = "ALL",
@@ -44,226 +44,216 @@ updateDataCounts <- function(session,
                              revocation.period.data.count = c(NA,NA),
                              keep.revocation.na.data.count = TRUE,
                              submission.period.data.count = c(NA,NA),
-                             intervention.types.data.count = "",
+                             intervention.types.data.count = "all",
                              keep.type.data.count = TRUE,
                              group.type.data.count = TRUE,
-                             mast.chapters.data.count = "",
+                             mast.chapters.data.count = "all",
                              keep.mast.data.count = TRUE,
                              group.mast.data.count = TRUE,
                              implementation.level.data.count = "any",
                              keep.level.data.count = TRUE,
                              eligible.firms.data.count = "any",
                              keep.firms.data.count = TRUE,
-                             cpc.sectors.data.count = "",
+                             cpc.sectors.data.count = "all",
                              keep.cpc.data.count = TRUE,
                              group.cpc.data.count = TRUE,
                              all.service.cpc.data.count = TRUE,
-                             hs.codes.data.count = "",
+                             hs.codes.data.count = "all",
                              keep.hs.data.count = TRUE,
                              intervention.ids.data.count = "",
                              keep.interventions.data.count = TRUE,
                              lag.adjustment.data.count = NA) {
-
-
-    updateSelectInput(session,
-                      "gta.evaluation.data.count",
-                      selected = gta.evaluation.data.count)
-
-
-    updateSelectInput(session,
-                      "affected.flows.data.count",
-                      selected = affected.flows.data.count)
-
-
-    updateMultiInput(session,
-                     "implementers.data.count",
-                     selected = implementers.data.count)
-
-
-    updateCheckboxInput(session,
-                        "keep.implementer.data.count",
-                        value = keep.implementer.data.count)
-
-    updateCheckboxInput(session,
-                        "group.implementer.data.count",
-                        value = group.implementer.data.count)
-
-
-    updateMultiInput(session,
-                     "affected.data.count",
-                     selected = affected.data.count)
-
-
-    updateCheckboxInput(session,
-                        "keep.affected.data.count",
-                        value = keep.affected.data.count)
-
-
-    updateCheckboxInput(session,
-                        "group.affected.data.count",
-                        value = group.affected.data.count)
-
-
-    updateCheckboxInput(session,
-                        "keep.others.data.count",
-                        value = keep.others.data.count)
-
-    updateSelectInput(session,
-                      "incl.affected.strictness.data.count",
-                      value = incl.affected.strictness.data.count)
-    
-    updateTextInput(session,
-                    "nr.affected.data.count",
-                    value = nr.affected.data.count)
-    
-    updateSelectInput(session,
-                      "nr.affected.incl.data.count",
-                      value = nr.affected.incl.data.count)
-
-    
-    updateNumericInput(session,
-                       "affected.also.nr.data.count",
-                       value = affected.also.nr.data.count)
-
-
-    updateCheckboxInput(session,
-                        "affected.jointly.data.count",
-                        value = affected.jointly.data.count)
-
-
-    updateCheckboxInput(session,
-                        "in.force.today.data.count",
-                        value = in.force.today.data.count)
-
-
-    updateCheckboxInput(session,
-                        "in.force.today.data.count",
-                        value = in.force.today.data.count)
-
-
-    updateDateRangeInput(session,
-                         "announcement.period.data.count",
-                         start = announcement.period.data.count[1],
-                     end = announcement.period.data.count[2])
-
-
-    updateDateRangeInput(session,
-                         "implementation.period.data.count",
-                         start = implementation.period.data.count[1],
-                     end = implementation.period.data.count[2])
-
-
-    updateDateRangeInput(session,
-                         "revocation.period.data.count",
-                         start = revocation.period.data.count[1],
-                     end = revocation.period.data.count[2])
-
-
-
-    updateDateRangeInput(session,
-                         "submission.period.data.count",
-                         start = submission.period.data.count[1],
-                     end = submission.period.data.count[2])
-
-
-    updateMultiInput(session,
-                     "intervention.types.data.count",
-                     selected = intervention.types.data.count)
-
-
-    updateMultiInput(session,
-                     "intervention.types.data.count",
-                     selected = intervention.types.data.count)
-
-
-    updateCheckboxInput(session,
-                        "keep.type.data.count",
-                        value = keep.type.data.count)
-
-
-    updateCheckboxInput(session,
-                        "group.type.data.count",
-                        value = group.type.data.count)
-
-
-    updateMultiInput(session,
-                     "mast.chapters.data.count",
-                     selected = mast.chapters.data.count)
-
-
-    updateCheckboxInput(session,
-                        "keep.mast.data.count",
-                        value = keep.mast.data.count)
-
-
-    updateCheckboxInput(session,
-                        "group.mast.data.count",
-                        value = group.mast.data.count)
-
-
-    updateMultiInput(session,
-                     "implementation.level.data.count",
-                     selected = implementation.level.data.count)
-
-
-    updateCheckboxInput(session,
-                        "keep.level.data.count",
-                        value = keep.level.data.count)
-
-
-    updateMultiInput(session,
-                     "eligible.firms.data.count",
-                     selected = eligible.firms.data.count)
-
-
-    updateCheckboxInput(session,
-                        "keep.firms.data.count",
-                        value = keep.firms.data.count)
-
-
-    updateMultiInput(session,
-                     "cpc.sectors.data.count",
-                     selected = cpc.sectors.data.count)
-
-
-    updateCheckboxInput(session,
-                        "keep.cpc.data.count",
-                        value = keep.cpc.data.count)
-    
-    updateCheckboxInput(session,
-                        "group.cpc.data.count",
-                        value = group.cpc.data.count)
-    
-    updateCheckboxInput(session,
-                        "all.service.cpc.data.count",
-                        value = all.service.cpc.data.count)
-
-
-    updateMultiInput(session,
-                     "hs.codes.data.count",
-                     selected = hs.codes.data.count)
-
-
-
-    updateCheckboxInput(session,
-                        "keep.hs.data.count",
-                        value = keep.hs.data.count)
-
-
-    updateTextInput(session,
-                    "intervention.ids.data.count",
-                    value = intervention.ids.data.count)
-
-
-    updateCheckboxInput(session,
-                        "keep.interventions.data.count",
-                        value = keep.interventions.data.count)
-
-
-    updateDateInput(session,
-                    "lag.adjustment.data.count",
-                    value = lag.adjustment.data.count)
-
-
-
+  
+  
+  updateSelectInput(session,
+                    "gta.evaluation.data.count",
+                    selected = gta.evaluation.data.count)
+  
+  
+  updateSelectInput(session,
+                    "affected.flows.data.count",
+                    selected = affected.flows.data.count)
+  
+  
+  updateMultiInput(session,
+                   "implementers.data.count",
+                   selected = implementers.data.count)
+  
+  
+  updateCheckboxInput(session,
+                      "keep.implementer.data.count",
+                      value = keep.implementer.data.count)
+  
+  updateCheckboxInput(session,
+                      "group.implementer.data.count",
+                      value = group.implementer.data.count)
+  
+  
+  updateMultiInput(session,
+                   "affected.data.count",
+                   selected = affected.data.count)
+  
+  
+  updateCheckboxInput(session,
+                      "keep.affected.data.count",
+                      value = keep.affected.data.count)
+  
+  
+  updateCheckboxInput(session,
+                      "group.affected.data.count",
+                      value = group.affected.data.count)
+  
+  
+  updateCheckboxInput(session,
+                      "keep.others.data.count",
+                      value = keep.others.data.count)
+  
+  updateSelectInput(session,
+                    "incl.affected.strictness.data.count",
+                    selected = incl.affected.strictness.data.count)
+  
+  updateTextInput(session,
+                  "nr.affected.data.count",
+                  value = nr.affected.data.count)
+  
+  updateSelectInput(session,
+                    "nr.affected.incl.data.count",
+                    selected = nr.affected.incl.data.count)
+  
+  
+  updateCheckboxInput(session,
+                      "in.force.today.data.count",
+                      value = in.force.today.data.count)
+  
+  
+  updateCheckboxInput(session,
+                      "in.force.today.data.count",
+                      value = in.force.today.data.count)
+  
+  
+  updateDateRangeInput(session,
+                       "announcement.period.data.count",
+                       start = announcement.period.data.count[1],
+                       end = announcement.period.data.count[2])
+  
+  
+  updateDateRangeInput(session,
+                       "implementation.period.data.count",
+                       start = implementation.period.data.count[1],
+                       end = implementation.period.data.count[2])
+  
+  
+  updateDateRangeInput(session,
+                       "revocation.period.data.count",
+                       start = revocation.period.data.count[1],
+                       end = revocation.period.data.count[2])
+  
+  
+  
+  updateDateRangeInput(session,
+                       "submission.period.data.count",
+                       start = submission.period.data.count[1],
+                       end = submission.period.data.count[2])
+  
+  
+  updateMultiInput(session,
+                   "intervention.types.data.count",
+                   selected = intervention.types.data.count)
+  
+  
+  updateMultiInput(session,
+                   "intervention.types.data.count",
+                   selected = intervention.types.data.count)
+  
+  
+  updateCheckboxInput(session,
+                      "keep.type.data.count",
+                      value = keep.type.data.count)
+  
+  
+  updateCheckboxInput(session,
+                      "group.type.data.count",
+                      value = group.type.data.count)
+  
+  
+  updateMultiInput(session,
+                   "mast.chapters.data.count",
+                   selected = mast.chapters.data.count)
+  
+  
+  updateCheckboxInput(session,
+                      "keep.mast.data.count",
+                      value = keep.mast.data.count)
+  
+  
+  updateCheckboxInput(session,
+                      "group.mast.data.count",
+                      value = group.mast.data.count)
+  
+  
+  updateMultiInput(session,
+                   "implementation.level.data.count",
+                   selected = implementation.level.data.count)
+  
+  
+  updateCheckboxInput(session,
+                      "keep.level.data.count",
+                      value = keep.level.data.count)
+  
+  
+  updateMultiInput(session,
+                   "eligible.firms.data.count",
+                   selected = eligible.firms.data.count)
+  
+  
+  updateCheckboxInput(session,
+                      "keep.firms.data.count",
+                      value = keep.firms.data.count)
+  
+  
+  updateMultiInput(session,
+                   "cpc.sectors.data.count",
+                   selected = cpc.sectors.data.count)
+  
+  
+  updateCheckboxInput(session,
+                      "keep.cpc.data.count",
+                      value = keep.cpc.data.count)
+  
+  updateCheckboxInput(session,
+                      "group.cpc.data.count",
+                      value = group.cpc.data.count)
+  
+  updateCheckboxInput(session,
+                      "all.service.cpc.data.count",
+                      value = all.service.cpc.data.count)
+  
+  
+  updateMultiInput(session,
+                   "hs.codes.data.count",
+                   selected = hs.codes.data.count)
+  
+  
+  
+  updateCheckboxInput(session,
+                      "keep.hs.data.count",
+                      value = keep.hs.data.count)
+  
+  
+  updateTextInput(session,
+                  "intervention.ids.data.count",
+                  value = intervention.ids.data.count)
+  
+  
+  updateCheckboxInput(session,
+                      "keep.interventions.data.count",
+                      value = keep.interventions.data.count)
+  
+  
+  updateDateInput(session,
+                  "lag.adjustment.data.count",
+                  value = lag.adjustment.data.count)
+  
+  
+  
 }

--- a/code/order processing/GTA data kitchen order - count statistics.R
+++ b/code/order processing/GTA data kitchen order - count statistics.R
@@ -1,554 +1,713 @@
 # # UNCOMMENT FOR TESTING
-# 
-# # library(gtalibrary)
+#
+# library(gtalibrary)
 # setwd("/Users/patrickbuess/Dropbox/Collaborations/GTA cloud")
 # load("0 dev/data-kitchen-pb/log/kitchen log.Rdata")
-# kl = kitchen.log[667,]
+# kl = kitchen.log[nrow(kitchen.log)-1,]
 
 # PROCESSING
 
-library(openxlsx)
+# path = "17 Shiny/4 data kitchen/"
+path = "0 dev/data-kitchen-pb/"
+
+library(xlsx)
 
 tryCatch({
-
-if(as.character(kl$gta.evaluation)!=""){
-  gta.eval=paste(unlist(strsplit(as.character(kl$gta.evaluation),",")))}else{gta.eval=NULL}
-
-if(as.character(kl$affected.flows)!=""){
-  a.flow=paste(unlist(strsplit(as.character(kl$affected.flows),",")))}else{a.flow=NULL}
-
-if(as.character(kl$implementers)!=""){
-  ij=paste(unlist(strsplit(as.character(kl$implementers),",")))
-  ij <- ij[ij != ""]}else{ij=NULL}
-
-if(as.character(kl$affected)!=""){
-  aff=paste(unlist(strsplit(as.character(kl$affected),",")))
-  aff <- aff[aff != ""]}else{aff=NULL}
   
-if(as.character(kl$incl.affected.strictness)!=""){
-  incl.aff.str=paste(unlist(strsplit(as.character(kl$incl.affected.strictness),",")))}else{incl.aff.str=NULL}
-
-if(as.character(kl$nr.affected)!=""){
-  nr.aff=as.numeric(paste(unlist(strsplit(as.character(kl$nr.affected),","))))
-  nr.aff <- nr.aff[is.na(nr.aff)==F]}else{nr.aff=c(0,999)}
-
-if(as.character(kl$nr.affected.incl)!=""){
-  nr.aff.incl=paste(unlist(strsplit(as.character(kl$nr.affected.incl),",")))}else{nr.aff.incl=NULL}
-
+  if(as.character(kl$gta.evaluation)!=""){
+    gta.eval=paste(unlist(strsplit(as.character(kl$gta.evaluation),",")))}else{gta.eval=NULL}
   
-if(as.character(kl$announcement.period)!="NA,NA"){
-  a.period=paste(unlist(strsplit(as.character(kl$announcement.period),",")))
-  a.period[a.period=="NA"] <- NA
+  if(as.character(kl$affected.flows)!=""){
+    a.flow=paste(unlist(strsplit(as.character(kl$affected.flows),",")))}else{a.flow=NULL}
+  
+  if(as.character(kl$implementers)!=""){
+    ij=paste(unlist(strsplit(as.character(kl$implementers),",")))
+    ij <- ij[ij != ""]}else{ij=NULL}
+  
+  if(as.character(kl$affected)!=""){
+    aff=paste(unlist(strsplit(as.character(kl$affected),",")))
+    aff <- aff[aff != ""]}else{aff=NULL}
+  
+  if(as.character(kl$incl.affected.strictness)!=""){
+    incl.aff.str=paste(unlist(strsplit(as.character(kl$incl.affected.strictness),",")))}else{incl.aff.str=NULL}
+  
+  if(as.character(kl$nr.affected)!=""){
+    nr.aff=as.numeric(paste(unlist(strsplit(as.character(kl$nr.affected),","))))
+    nr.aff <- nr.aff[is.na(nr.aff)==F]}else{nr.aff=c(0,999)}
+  
+  if(as.character(kl$nr.affected.incl)!=""){
+    nr.aff.incl=paste(unlist(strsplit(as.character(kl$nr.affected.incl),",")))}else{nr.aff.incl=NULL}
+  
+  
+  if(as.character(kl$announcement.period)!="NA,NA"){
+    a.period=paste(unlist(strsplit(as.character(kl$announcement.period),",")))
+    a.period[a.period=="NA"] <- NA
   }else{a.period=NULL}
-
-if(as.character(kl$implementation.period)!="NA,NA"){
-  i.period=paste(unlist(strsplit(as.character(kl$implementation.period),",")))
-  i.period[i.period=="NA"] <- NA
+  
+  if(as.character(kl$implementation.period)!="NA,NA"){
+    i.period=paste(unlist(strsplit(as.character(kl$implementation.period),",")))
+    i.period[i.period=="NA"] <- NA
   }else{i.period=NULL}
-
-if(as.character(kl$revocation.period)!="NA,NA"){
-  r.period=paste(unlist(strsplit(as.character(kl$revocation.period),",")))
-  r.period[r.period=="NA"] <- NA
+  
+  if(as.character(kl$revocation.period)!="NA,NA"){
+    r.period=paste(unlist(strsplit(as.character(kl$revocation.period),",")))
+    r.period[r.period=="NA"] <- NA
   }else{r.period=NULL}
-
-if(as.character(kl$submission.period)!="NA,NA"){
-  s.period=paste(unlist(strsplit(as.character(kl$submission.period),",")))
-  s.period[s.period=="NA"] <- NA
+  
+  if(as.character(kl$submission.period)!="NA,NA"){
+    s.period=paste(unlist(strsplit(as.character(kl$submission.period),",")))
+    s.period[s.period=="NA"] <- NA
   }else{s.period=NULL}
-
-if(as.character(kl$in.force.today)!=""){
-  ift=paste(unlist(strsplit(as.character(kl$in.force.today),",")))}else{ift=NULL}
-
-if(as.character(kl$intervention.types)!=""){
-  i.types=paste(unlist(strsplit(as.character(kl$intervention.types),",")))
-  i.types <- i.types[i.types != ""]
-  nes.list <- c("Import-related non-tariff measure","Export-related non-tariff measure","Public procurement","State aid","FDI: Treatment and operations")
-  if (any(i.types %in% nes.list)){
-    for (i in 1:length(i.types)){
-      if (i.types[i] %in% nes.list){i.types[i] <- paste0(i.types[i],", nes")}
-      if (i.types[i] ==" nes"){i.types[i] <- 0}}
-    i.types <- i.types[i.types!=0]
+  
+  if(as.character(kl$in.force.today)!=""){
+    ift=paste(unlist(strsplit(as.character(kl$in.force.today),",")))}else{ift=NULL}
+  
+  if(as.character(kl$intervention.types)!=""){
+    i.types=paste(unlist(strsplit(as.character(kl$intervention.types),",")))
+    i.types <- i.types[i.types != ""]
+    nes.list <- c("Import-related non-tariff measure","Export-related non-tariff measure","Public procurement","State aid","FDI: Treatment and operations")
+    if (any(i.types %in% nes.list)){
+      for (i in 1:length(i.types)){
+        if (i.types[i] %in% nes.list){i.types[i] <- paste0(i.types[i],", nes")}
+        if (i.types[i] ==" nes"){i.types[i] <- 0}}
+      i.types <- i.types[i.types!=0]
     }}else{i.types=NULL}
-
-if(as.character(kl$mast.chapters)!=""){
-  mast=paste(unlist(strsplit(as.character(kl$mast.chapters),",")))
-  mast <- mast[mast != ""]}else{mast=NULL}
-
-if(! grepl("any", as.character(kl$implementation.level))){
-  il=paste(unlist(strsplit(as.character(kl$implementation.level),",")))}else{il=NULL}
-
-if(! grepl("any", as.character(kl$eligible.firms))){
-  ef=paste(unlist(strsplit(as.character(kl$eligible.firms),",")))}else{ef=NULL}
-
+  
+  if(as.character(kl$mast.chapters)!=""){
+    mast=paste(unlist(strsplit(as.character(kl$mast.chapters),",")))
+    mast <- mast[mast != ""]}else{mast=NULL}
+  
+  if(! grepl("any", as.character(kl$implementation.level))){
+    il=paste(unlist(strsplit(as.character(kl$implementation.level),",")))}else{il=NULL}
+  
+  if(! grepl("any", as.character(kl$eligible.firms))){
+    ef=paste(unlist(strsplit(as.character(kl$eligible.firms),",")))}else{ef=NULL}
+  
   
   # CHECK WHETHER ALL SERVICE OR ALL GOODS ARE CHOSEN
-if (any(c("all_service","all_goods") %in% unlist(strsplit(as.character(kl$cpc.sectors),",")))) {
-  if ("all_service" %in% unlist(strsplit(as.character(kl$cpc.sectors),","))) {
-    cpc_new <- subset(gtalibrary::cpc.names, cpc > 499 & cpc.digit.level == 3)$cpc
-    temp <- unlist(strsplit(as.character(kl$cpc.sectors),","))
-    temp <- temp[temp != "all_service"]
-    temp <- append(temp, cpc_new)
-    kl$cpc.sectors <- paste(temp, collapse = ",")
-    rm(temp)
+  if (any(c("all_service","all_goods") %in% unlist(strsplit(as.character(kl$cpc.sectors),",")))) {
+    if ("all_service" %in% unlist(strsplit(as.character(kl$cpc.sectors),","))) {
+      cpc_new <- subset(gtalibrary::cpc.names, cpc > 499 & cpc.digit.level == 3)$cpc
+      temp <- unlist(strsplit(as.character(kl$cpc.sectors),","))
+      temp <- temp[temp != "all_service"]
+      temp <- append(temp, cpc_new)
+      kl$cpc.sectors <- paste(temp, collapse = ",")
+      rm(temp)
+    }
+    if ("all_goods" %in% unlist(strsplit(as.character(kl$cpc.sectors),","))) {
+      cpc_new <- subset(gtalibrary::cpc.names, cpc < 500 & cpc.digit.level == 3)$cpc
+      temp <- unlist(strsplit(as.character(kl$cpc.sectors),","))
+      temp <- temp[temp != "all_goods"]
+      temp <- append(temp, cpc_new)
+      kl$cpc.sectors <- paste(temp, collapse = ",")
+      rm(temp)
+    }
   }
-  if ("all_goods" %in% unlist(strsplit(as.character(kl$cpc.sectors),","))) {
-    cpc_new <- subset(gtalibrary::cpc.names, cpc < 500 & cpc.digit.level == 3)$cpc
-    temp <- unlist(strsplit(as.character(kl$cpc.sectors),","))
-    temp <- temp[temp != "all_goods"]
-    temp <- append(temp, cpc_new)
-    kl$cpc.sectors <- paste(temp, collapse = ",")
-    rm(temp)
-  }
-}
   
-if(as.character(kl$cpc.sectors)!=""){
-  cpc=as.numeric(paste(unlist(strsplit(as.character(kl$cpc.sectors),","))))
-  cpc <- cpc[is.na(cpc)==F]}else{cpc=NULL}
-
-if(as.character(kl$hs.codes)!=""){
-  hs=as.numeric(paste(unlist(strsplit(as.character(kl$hs.codes),","))))
-  hs <- hs[is.na(hs)==F]}else{hs=NULL}
-
-if(as.character(kl$intervention.ids)!=""){
-  int.id=paste(unlist(strsplit(as.character(kl$intervention.ids),",")))}else{int.id=NULL}
-
-if(as.character(kl$lag.adjustment)!=""){
-  lag=paste(paste(unlist(strsplit(as.character(kl$lag.adjustment),"-")))[2],
-            paste(unlist(strsplit(as.character(kl$lag.adjustment),"-")))[3],sep="-")}else{lag=NULL}
-
-
-## running the function
-gta_data_slicer(
-  data.path="data/master_plus.Rdata",
-  gta.evaluation= gta.eval,
-  affected.flows = a.flow,
-  implementing.country = ij,
-  keep.implementer = kl$keep.implementer==T,
-  affected.country = aff,
-  keep.affected = kl$keep.affected==T,
-  incl.affected.strictness = incl.aff.str,
-  keep.others = kl$keep.others==T,
-  nr.affected = nr.aff, 
-  nr.affected.incl = nr.aff.incl,
-  announcement.period = a.period,
-  implementation.period = i.period,
-  keep.implementation.na = kl$keep.implementation.na == T,
-  revocation.period = r.period,
-  keep.revocation.na = kl$keep.revocation.na == T,
-  submission.period = s.period,
-  in.force.today = ift,
-  intervention.types = i.types,
-  keep.type = kl$keep.type==T,
-  mast.chapters = mast,
-  keep.mast = kl$keep.mast==T,
-  implementation.level = il,
-  keep.level = kl$keep.level==T,
-  eligible.firms = ef,
-  keep.firms = kl$keep.firms==T,
-  cpc.sectors = cpc,
-  keep.cpc = kl$keep.cpc==T,
-  hs.codes = hs,
-  keep.hs = kl$keep.hs==T,
-  intervention.ids = int.id,
-  keep.interventions = kl$keep.interventions==T,
-  lag.adjustment=lag
-)
-
-
-if (error.message[1] == T) {
-  error.message <- error.message
-} else {
-
-  error.message <<- c(F,"")
-
-rm(gta.eval,a.flow,ij,aff,a.period,i.period,r.period,s.period,ift,i.types,mast,il,ef,cpc,hs,int.id,lag, a.a.nr)
-
-
-
-# Processing of sliced master dataset
-
+  # CHECK IF PRODUCT GROUPS ARE CHOSEN FOR CPC
+  product.groups <- gtalibrary::hs.codes
+  product.groups <- names(product.groups)
+  product.groups <- product.groups[grepl("is.", product.groups)]
+  product.groups <- gsub("is.","",product.groups)
+  product.groups <- gsub("\\."," ",product.groups)
+  
+  if (any(tolower(c(product.groups)) %in% tolower(unlist(strsplit(as.character(kl$cpc.sectors),","))))) {
+    groups <- product.groups[tolower(product.groups) %in% tolower(unlist(strsplit(as.character(kl$cpc.sectors),",")))]
+    groups <- paste0("is.", tolower(gsub(" ","\\.",groups)))
+    cpc_new <- c()
+    for (i in groups) {
+      eval(parse(text = paste0("temp <- subset(gtalibrary::hs.codes, ",i,"==T)$hs.code")))
+      temp <- gta_hs_to_cpc(temp)
+      temp <- unique(as.numeric(substr(temp, 1,3)))
+      cpc_new <- c(cpc_new, temp)
+    }
+    temp <- unique(unlist(strsplit(as.character(kl$cpc.sectors),",")))
+    temp <- unique(c(temp, cpc_new))
+    kl$cpc.sectors <- paste(temp[! tolower(temp) %in% tolower(product.groups)], collapse=",")
+  }
+  
+  if(as.character(kl$cpc.sectors)!=""){
+    cpc=paste(unlist(strsplit(as.character(kl$cpc.sectors),",")))
+    cpc <- cpc[is.na(cpc)==F]}else{cpc=NULL}
+  
+  # CHECK WHETHER PRODUCT GROUPS ARE IN HS CODES
+  if (any(tolower(c(product.groups)) %in% tolower(unlist(strsplit(as.character(kl$hs.codes),","))))) {
+    groups <- product.groups[tolower(product.groups) %in% tolower(unlist(strsplit(as.character(kl$hs.codes),",")))]
+    groups <- paste0("is.", tolower(gsub(" ","\\.",groups)))
+    hs_new <- c()
+    for (i in groups) {
+      eval(parse(text = paste0("temp <- subset(gtalibrary::hs.codes, ",i,"==T)$hs.code")))
+      temp <- gta_hs_code_check(temp)
+      hs_new <- c(hs_new, temp)
+    }
+    temp <- unique(unlist(strsplit(as.character(kl$hs.codes),",")))
+    temp <- unique(c(temp, hs_new))
+    kl$hs.codes <- paste(temp[! tolower(temp) %in% tolower(product.groups)], collapse=",")
+  }
+  
+  if(as.character(kl$hs.codes)!=""){
+    hs=paste(unlist(strsplit(as.character(kl$hs.codes),",")))
+    hs <- hs[is.na(hs)==F]}else{hs=NULL}
+  
+  if(as.character(kl$intervention.ids)!=""){
+    int.id=paste(unlist(strsplit(as.character(kl$intervention.ids),",")))}else{int.id=NULL}
+  
+  if(as.character(kl$lag.adjustment)!=""){
+    lag=paste(paste(unlist(strsplit(as.character(kl$lag.adjustment),"-")))[2],
+              paste(unlist(strsplit(as.character(kl$lag.adjustment),"-")))[3],sep="-")}else{lag=NULL}
+  
+  
+  # CHECK IF "ALL" VALUE IS INCLUDED ANYWHERE
+  # THESE WILL BE CALCULATED SEPARATELY IN A SECOND LOOP
+  additional.all <- c()
+  
+  types = list("aff" = aff,
+               "ij" = ij,
+               "cpc" = cpc,
+               "hs" = hs,
+               "mast" = mast,
+               "i.types" = i.types)
+  
+  for (i in 1:length(types)) {
+    if(length(types[[i]]) == 1 & types[[i]] == "all") {
+      eval(parse(text=paste0(names(types[i]),"= NULL")))  
+    } else if ("all" %in% types[[i]]) {
+      additional.all <- c(additional.all, names(types[i]))
+      eval(parse(text=paste0(names(types[i]),"=",names(types[i]),"[",names(types[i]),"!= 'all']")))
+    }  
+  }
+  
+  # CONVERT HS AND CPC TO NUMERIC IF NECESSARY
+  if (is.null(hs)==F){hs <- as.numeric(hs)}
+  if (is.null(cpc)==F){cpc <- as.numeric(cpc)}
+  
+  ## running the function
+  gta_data_slicer(
+    data.path="data/master_plus.Rdata",
+    gta.evaluation= gta.eval,
+    affected.flows = a.flow,
+    implementing.country = ij,
+    keep.implementer = kl$keep.implementer==T,
+    affected.country = aff,
+    keep.affected = kl$keep.affected==T,
+    incl.affected.strictness = incl.aff.str,
+    keep.others = kl$keep.others==T,
+    nr.affected = nr.aff, 
+    nr.affected.incl = nr.aff.incl,
+    announcement.period = a.period,
+    implementation.period = i.period,
+    keep.implementation.na = kl$keep.implementation.na == T,
+    revocation.period = r.period,
+    keep.revocation.na = kl$keep.revocation.na == T,
+    submission.period = s.period,
+    in.force.today = ift,
+    intervention.types = i.types,
+    keep.type = kl$keep.type==T,
+    mast.chapters = mast,
+    keep.mast = kl$keep.mast==T,
+    implementation.level = il,
+    keep.level = kl$keep.level==T,
+    eligible.firms = ef,
+    keep.firms = kl$keep.firms==T,
+    cpc.sectors = cpc,
+    keep.cpc = kl$keep.cpc==T,
+    hs.codes = hs,
+    keep.hs = kl$keep.hs==T,
+    intervention.ids = int.id,
+    keep.interventions = kl$keep.interventions==T,
+    lag.adjustment=lag
+  )
+  
+  master <- list(master.sliced)
+  p.choices <- list(parameter.choice.slicer)
+  
+  # Only make interventions list from selected part, because including "All" values would make it too large
   if (kl$interventions.list==T) {
-
+    
     interventions.list <- master.sliced
     interventions.list$url <- paste("https://www.globaltradealert.org/state-act/", interventions.list$state.act.id, sep="")
     interventions.list <- interventions.list[,c("intervention.id","url","implementing.jurisdiction","intervention.type","gta.evaluation","title")]
     names(interventions.list) <- c("ID","URL","Implementer","Instrument","Evaluation","Title")
     interventions.list <- unique(interventions.list)
-
-    xlsxList <- list("Interventions List" = interventions.list, "Parameter choices" = parameter.choice.slicer)
-    write.xlsx(x=xlsxList, file = paste("17 Shiny/4 data kitchen/results/Interventions list from ", Sys.Date(),".xlsx", sep=""), rowNames = F)
-    # write.xlsx(x=parameter.choice.slicer, file = paste("17 Shiny/4 data kitchen/results/Interventions list from ", Sys.Date(),".xlsx", sep=""), sheetName = "Parameter choices", append=T, row.names = F)
+    
+    # eval(parse(text=paste0("xlsxList = list('",sheetnames.int[i],"' = interventions.list, '",sheetnames.int[i+2],"' = parameter.choice.slicer)")))
+    # xlsxList <- list(paste0(sheetnames.int[i]) = interventions.list, paste0(sheetnames.int[i+2]) = parameter.choice.slicer)
+    write.xlsx(x=interventions.list, file = paste(path,"results/Interventions list from ", Sys.Date(),".xlsx", sep=""), sheetName = "Interventions list", rowNames = F, append = F)
+    write.xlsx(x=parameter.choice.slicer, file = paste(path,"results/Interventions list from ", Sys.Date(),".xlsx", sep=""), sheetName = "Parameter choices", append = T, row.names = F)
     rm(interventions.list)
-
   }
-
-  if (kl$aggregate.y=="affected.product") {
-    master.sliced <- cSplit(master.sliced, which(colnames(master.sliced)=="affected.product"), direction="long", sep=",")
-  }
-
-  if (kl$aggregate.y=="affected.sector" | kl$group.cpc == F) {
-    master.sliced <- cSplit(master.sliced, which(colnames(master.sliced)=="affected.sector"), direction="long", sep=",")
-  }
-
-  if (grepl("gta.evaluation.harmful.liberalising", as.character(kl$aggregate.x))){
-    master.sliced$gta.evaluation[master.sliced$gta.evaluation %in% c("Red","Amber")] = "Harmful"
-    master.sliced$gta.evaluation[master.sliced$gta.evaluation =="Green"] = "Liberalising"
-    names(master.sliced)[names(master.sliced) == 'gta.evaluation'] <- 'gta.evaluation.harmful.liberalising'
-  }
-
-
-if(as.character(kl$aggregate.y)!=""){
-  agg.y=paste(unlist(strsplit(as.character(kl$aggregate.y),",")))}else{agg.y=NULL}
-
-if(as.character(kl$aggregate.x)!=""){
-  agg.x=paste(unlist(strsplit(as.character(kl$aggregate.x),",")))
-  }else{
-    stop("Please specify at least one X variable for aggregation.")
-  }
-
-# CHECK IF OTHER PARAMETERS SHALL BE GROUPED OR NOT
-if(kl$group.implementer == F) {
-  agg.x <- append(agg.x, "implementing.jurisdiction")
-}
-
-if(kl$group.affected == F) {
-  agg.x <- append(agg.x, "affected.jurisdiction")
-}
-
-if(kl$group.mast == F) {
-  agg.x <- append(agg.x, "mast.chapter")
-}
-
-if(kl$group.type == F) {
-  agg.x <- append(agg.x, "intervention.type")
-}
-
-if(kl$group.cpc == F) {
-  agg.x <- append(agg.x, "affected.sector")
-}
-
-if(as.character(kl$aggregate.style)!=""){
-  agg.style=paste(unlist(strsplit(as.character(kl$aggregate.style),",")))}else{agg.style=NULL}
-
-
-agg.x <- unique(agg.x)
-eval(parse(text=paste0("agg <- aggregate(",agg.y," ~ ",paste(agg.x, collapse = "+"), ", master.sliced, function(x) ", agg.style, ")")))
-
-agg[is.na(agg)] <- 0
-
-if (kl$xlsx == T) {
-
-  if( (length(agg.x)>1) & TRUE %in% grepl("year", agg.x) ){
-
-      agg.xlsx=reshape(agg, idvar=agg.x[grepl("year", agg.x)==F], timevar =agg.x[grepl("year", agg.x)==T] , direction="wide")
-
-      names(agg.xlsx)=gsub(paste(as.character(agg.y),".", sep=""),"", names(agg.xlsx))
-
-      agg.xlsx[is.na(agg.xlsx)]=0
-      xlsxList = list("Count Statistics" = agg.xlsx, "Parameter choices" = parameter.choice.slicer)
-      write.xlsx(x=xlsxList, file = paste("17 Shiny/4 data kitchen/results/Count statistics from ", Sys.Date(),".xlsx", sep=""), rowNames = F)
-      # write.xlsx(x=parameter.choice.slicer, file = paste("17 Shiny/4 data kitchen/results/Count statistics from ", Sys.Date(),".xlsx", sep=""), sheetName = "Parameter choices", append=T, row.names = F)
-
-
-  } else{
-    xlsxList = list("Count Statistics" = agg, "Parameter choices" = parameter.choice.slicer)
-    write.xlsx(x=xlsxList, file = paste("17 Shiny/4 data kitchen/results/Count statistics from ", Sys.Date(),".xlsx", sep=""), rowNames = F)
-    # write.xlsx(x=agg, file = paste("17 Shiny/4 data kitchen/results/Count statistics from ", Sys.Date(),".xlsx", sep=""), sheetName = "Count Statistics", append=F, row.names = F)
-    # write.xlsx(x=parameter.choice.slicer, file = paste("17 Shiny/4 data kitchen/results/Count statistics from ", Sys.Date(),".xlsx", sep=""), sheetName = "Parameter choices", append=T, row.names = F)
-  }
-
-
-}
-
-gta_colour_palette()
-
-
-# MAP OUTPUT
-if (kl$map == T) {
-
-  if(as.character(kl$map.title)!=""){
-    title=paste(unlist(strsplit(as.character(kl$map.title),",")))}else{title=NULL}
-
-  if(as.character(kl$map.legend.title)!=""){
-    legend.title=paste(unlist(strsplit(as.character(kl$map.legend.title),",")))}else{legend.title=NULL}
-
-  if(as.character(kl$map.colour.low)!=""){
-    eval(parse(text=paste0("colour.low <- ",kl$map.colour.low)))}else{colour.low=NULL}
-
-  if(as.character(kl$map.colour.high)!=""){
-    eval(parse(text=paste0("colour.high <- ",kl$map.colour.high)))}else{colour.high=NULL}
-
-  if(as.character(kl$map.countries)!=""){
-    countries=paste(unlist(strsplit(as.character(kl$map.countries),",")))}else{countries=NULL}
-
-  if(as.character(kl$map.value)!=""){
-    value=paste(unlist(strsplit(as.character(kl$map.value),",")))}else{value=NULL}
-
-  eval(parse(text=paste0("data <- aggregate(`",value,"` ~ `",countries,"`, agg, function(x) sum(x))")))
-
-  map <- gta_plot_map(data = data, countries = countries, value = value, title = title, legend.title = legend.title, colour.high = colour.high, colour.low = colour.low)
-
-  gta_plot_saver(plot = map, path = "17 Shiny/4 data kitchen/results", name = paste("Map chart from ", Sys.Date(), sep=""), eps=F)
-
-  rm(map, colour.low, colour.high, value, countries, legend.title)
-
-}
-
-# TILE CHART OUTPUT
-if (kl$tile == T) {
-
-  if(as.character(kl$tile.title)!=""){
-    title=paste(unlist(strsplit(as.character(kl$tile.title),",")))}else{title=NULL}
-
-  if(as.character(kl$tile.legend.title)!=""){
-    legend.title=paste(unlist(strsplit(as.character(kl$tile.legend.title),",")))}else{legend.title=NULL}
-
-  if(as.character(kl$tile.x.axis.title)!=""){
-    x.axis=paste(unlist(strsplit(as.character(kl$tile.x.axis.title),",")))}else{x.axis=NULL}
-
-  if(as.character(kl$tile.y.axis.title)!=""){
-    y.axis=paste(unlist(strsplit(as.character(kl$tile.y.axis.title),",")))}else{y.axis=NULL}
-
-  if(as.character(kl$tile.colour.low)!=""){
-    eval(parse(text=paste0("colour.low <- ",kl$tile.colour.low)))}else{colour.low=NULL}
-
-  if(as.character(kl$tile.colour.high)!=""){
-    eval(parse(text=paste0("colour.high <- ",kl$tile.colour.high)))}else{colour.high=NULL}
-
-  if(as.character(kl$tile.x.var)!=""){
-    x.var=paste(unlist(strsplit(as.character(kl$tile.x.var),",")))}else{x.var=NULL}
-
-  if(as.character(kl$tile.y.var)!=""){
-    y.var=paste(unlist(strsplit(as.character(kl$tile.y.var),",")))}else{y.var=NULL}
-
-  if(as.character(kl$tile.value.var)!=""){
-    value=paste(unlist(strsplit(as.character(kl$tile.value.var),",")))}else{value=NULL}
-
-  eval(parse(text=paste0("data <- aggregate(`",value,"` ~ `",x.var,"`+`",y.var,"`, agg, function(x) sum(x))")))
-
-  tile <- gta_plot_tile(data = data, value.x = x.var, value.y = y.var, values = value, title = title, legend.title = legend.title, colour.low = colour.low, colour.high = colour.high, y.axis.name = y.axis, x.axis.name = x.axis)
-
-  gta_plot_saver(plot = tile, path = "17 Shiny/4 data kitchen/results", name = paste("Tile chart from ", Sys.Date(), sep=""), eps=F)
-
-  rm(tile, colour.low, colour.high, value, title, legend.title, x.var, y.var, x.axis, y.axis)
-
-}
-
-
-# LINE CHART OUTPUT
-if (kl$line == T) {
-
-  if(as.character(kl$line.title)!=""){
-    title=paste(unlist(strsplit(as.character(kl$line.title),",")))}else{title=NULL}
-
-  if(as.character(kl$line.legend.title)!=""){
-    legend.title=paste(unlist(strsplit(as.character(kl$line.legend.title),",")))}else{legend.title=NULL}
-
-  if(as.character(kl$line.x.axis.title)!=""){
-    x.axis=paste(unlist(strsplit(as.character(kl$line.x.axis.title),",")))}else{x.axis=NULL}
-
-  if(as.character(kl$line.y.axis.title)!=""){
-    y.axis=paste(unlist(strsplit(as.character(kl$line.y.axis.title),",")))}else{y.axis=NULL}
-
-  if(as.character(kl$line.x.var)!=""){
-    x.var=paste(unlist(strsplit(as.character(kl$line.x.var),",")))}else{x.var=NULL}
-
-  if(as.character(kl$line.y.var)!=""){
-    y.var=paste(unlist(strsplit(as.character(kl$line.y.var),",")))}else{y.var=NULL}
-
-  if(as.character(kl$line.group.var)!=""){
-    group=paste(unlist(strsplit(as.character(kl$line.group.var),",")))}else{group=NULL}
-
-  if(as.character(kl$line.colour)=="gta_colour$qualitative"){
-    eval(parse(text=paste0("colour <- ",kl$line.colour)))
-
-  } else if(as.character(kl$line.colour)!="gta_colour$qualitative"){
-    eval(parse(text=paste0("colour <- ",kl$line.colour,"(length(unique(agg$'",group,"')))")))
-
-    }else{colour=NULL}
-
-  if (is.null(group)==F) {
-    eval(parse(text=paste0("data <- aggregate(`",y.var,"` ~ `",x.var,"`+`",group,"`, agg, function(x) sum(x))"))) } else {
-      eval(parse(text=paste0("data <- aggregate(`",y.var,"` ~ `",x.var,"`, agg, function(x) sum(x))"))) }
-
-  data[,c("value.x","value.y")] <- data[,c(x.var, y.var)]
-
-  data$value.x.labels = data$value.x
-  data$value.y.labels = data$value.y
-  data$value.x.breaks = data$value.x
-  data$value.y.breaks = data$value.y
-
-  if (is.numeric(data$value.x)==F) {
-    data$value.x.breaks = as.numeric(data$value.x.breaks)
-    data$value.x.breaks.temp <- data$value.x.breaks
-    i = 1
-    for (h in unique(as.numeric(data$value.x))) {
-      data$value.x.breaks[data$value.x.breaks.temp==h] <-  i
-      i=i+1
+  
+  
+  # CALCULATE ALL VALUES IF NECESSARY
+  if(length(additional.all)>0) {
+    
+    # MAKE SECOND KL ROW TO BE ABLE TO CHANGE VALUE IN IT WHERE NECESSARY
+    kl2 <- as.data.frame(kl)
+    
+    types = list(c("aff", "group.affected","Affected jurisdictions"),
+                 c("ij", "group.implementer","Implementing jurisdiction"),
+                 c("cpc", "group.cpc","CPC Sectors"),
+                 c("hs", "group.hs","HS Codes"),
+                 c("mast", "group.mast","MAST Chapters"),
+                 c("i.types", "group.types","Intervention types"))
+    
+    for (i in 1:length(types)) {
+      if(types[[i]][1] %in% additional.all) {
+        eval(parse(text=paste0(types[[i]][1],"= NULL")))
+        eval(parse(text=paste0("kl2$",types[[i]][2],"= TRUE")))
+      }
     }
-    data$value.x.breaks.temp <- NULL
+    
+    ## running the function
+    gta_data_slicer(
+      data.path="data/master_plus.Rdata",
+      gta.evaluation= gta.eval,
+      affected.flows = a.flow,
+      implementing.country = ij,
+      keep.implementer = kl$keep.implementer==T,
+      affected.country = aff,
+      keep.affected = kl$keep.affected==T,
+      incl.affected.strictness = incl.aff.str,
+      keep.others = kl$keep.others==T,
+      nr.affected = nr.aff, 
+      nr.affected.incl = nr.aff.incl,
+      announcement.period = a.period,
+      implementation.period = i.period,
+      keep.implementation.na = kl$keep.implementation.na == T,
+      revocation.period = r.period,
+      keep.revocation.na = kl$keep.revocation.na == T,
+      submission.period = s.period,
+      in.force.today = ift,
+      intervention.types = i.types,
+      keep.type = kl$keep.type==T,
+      mast.chapters = mast,
+      keep.mast = kl$keep.mast==T,
+      implementation.level = il,
+      keep.level = kl$keep.level==T,
+      eligible.firms = ef,
+      keep.firms = kl$keep.firms==T,
+      cpc.sectors = cpc,
+      keep.cpc = kl$keep.cpc==T,
+      hs.codes = hs,
+      keep.hs = kl$keep.hs==T,
+      intervention.ids = int.id,
+      keep.interventions = kl$keep.interventions==T,
+      lag.adjustment=lag
+    )
+    
+    master <- list(master, master.sliced)
+    p.choices <- list(p.choices, parameter.choice.slicer)
+    kitchen.rows <- list(kl, kl2)
   }
-
-  if (is.numeric(data$value.y)==F) {
-    data$value.y.breaks = as.numeric(data$value.y.breaks)
-    data$value.y.breaks.temp <- data$value.y.breaks
-    i = 1
-    for (h in unique(as.numeric(data$value.y))) {
-      data$value.y.breaks[data$value.y.breaks.temp==h] <-  i
-      i=i+1
-    }
-    data$value.y.breaks.temp <- NULL
-  }
-
-  if (is.null(group)==T) {
-
-    line <- ggplot() +
-      geom_line(data=data, aes(x=value.x.breaks, y=value.y.breaks))+
-      scale_y_continuous(breaks = waiver(), labels = waiver(), sec.axis = sec_axis(~.,breaks = waiver(), name = y.axis, labels = waiver()))+
-      scale_x_continuous(breaks = unique(data$value.x.breaks), labels = unique(data$value.x.labels))+
-      ggtitle(title)+
-      labs(x=x.axis, y=y.axis)+
-      gta_theme(x.bottom.angle = 45,
-                x.bottom.align = 1)
-  }
-
-
-  if (is.null(group)==F) {
-
-    data[,c("group")] <- data[,c(group)]
-
-    data$group <- factor(data$group)
-    eval(parse(text=paste0("col <- round(sqrt((length(unique(agg$'",group,"')))),digits=0)")))
-
-    line <- ggplot() +
-      geom_line(data=data, aes(x=value.x.breaks, y=value.y.breaks, colour=group))+
-      scale_y_continuous(breaks = waiver(), labels = waiver(), sec.axis = sec_axis(~.,breaks = waiver(), name = y.axis, labels = waiver()))+
-      scale_x_continuous(breaks = unique(data$value.x.breaks), labels = unique(data$value.x.labels))+
-      scale_colour_manual(values=colour, labels=unique(data$group))+
-      ggtitle(title)+
-      labs(x=x.axis, y=y.axis)+
-      guides(colour = guide_legend(title=legend.title, ncol = col))+
-      gta_theme(x.bottom.angle = 45,
-                x.bottom.align = 1)
-  }
-
-  gta_plot_saver(plot = line, path = "17 Shiny/4 data kitchen/results", name = paste("Line chart from ", Sys.Date(), sep=""), eps=F)
-
-  rm(agg.line, line, colour, group, title, legend.title, x.var, y.var, x.axis, y.axis, col)
-
-}
-
-# BAR CHART OUTPUT
-if (kl$bar == T) {
-
-  if(as.character(kl$bar.title)!=""){
-    title=paste(unlist(strsplit(as.character(kl$bar.title),",")))}else{title=NULL}
-
-  if(as.character(kl$bar.legend.title)!=""){
-    legend.title=paste(unlist(strsplit(as.character(kl$bar.legend.title),",")))}else{legend.title=NULL}
-
-  if(as.character(kl$bar.x.axis.title)!=""){
-    x.axis=paste(unlist(strsplit(as.character(kl$bar.x.axis.title),",")))}else{x.axis=NULL}
-
-  if(as.character(kl$bar.y.axis.title)!=""){
-    y.axis=paste(unlist(strsplit(as.character(kl$bar.y.axis.title),",")))}else{y.axis=NULL}
-
-  if(as.character(kl$bar.colour)!=""){
-    eval(parse(text=paste0("colour <- ",kl$bar.colour)))}else{colour=NULL}
-
-  if(as.character(kl$bar.x.var)!=""){
-    x.var=paste(unlist(strsplit(as.character(kl$bar.x.var),",")))}else{x.var=NULL}
-
-  if(as.character(kl$bar.y.var)!=""){
-    y.var=paste(unlist(strsplit(as.character(kl$bar.y.var),",")))}else{y.var=NULL}
-
-  if(as.character(kl$bar.group.var)!=""){
-    group=paste(unlist(strsplit(as.character(kl$bar.group.var),",")))}else{group=NULL}
-
-  if(as.character(kl$bar.colour)=="gta_colour$qualitative"){
-    eval(parse(text=paste0("colour <- ",kl$bar.colour)))
-
-  } else if(as.character(kl$bar.colour)!="gta_colour$qualitative"){
-    eval(parse(text=paste0("colour <- ",kl$bar.colour,"(length(unique(agg$'",group,"')))")))
-
-  }else{colour=NULL}
-
-  if (is.null(group)==F) {
-    eval(parse(text=paste0("data <- aggregate(`",y.var,"` ~ `",x.var,"`+`",group,"`, agg, function(x) sum(x))"))) } else {
-      eval(parse(text=paste0("data <- aggregate(`",y.var,"` ~ `",x.var,"`, agg, function(x) sum(x))"))) }
-
-  data[,c("value.x","value.y")] <- data[,c(x.var, y.var)]
-
-  data$value.x.labels = data$value.x
-  data$value.y.labels = data$value.y
-  data$value.x.breaks = data$value.x
-  data$value.y.breaks = data$value.y
-
-  if (is.numeric(data$value.x)==F) {
-    data$value.x.breaks = as.numeric(data$value.x.breaks)
-    data$value.x.breaks.temp <- data$value.x.breaks
-    i = 1
-    for (h in unique(as.numeric(data$value.x))) {
-      data$value.x.breaks[data$value.x.breaks.temp==h] <-  i
-      i=i+1
-    }
-    data$value.x.breaks.temp <- NULL
-  }
-
-  if (is.numeric(data$value.y)==F) {
-    data$value.y.breaks = as.numeric(data$value.y.breaks)
-    data$value.y.breaks.temp <- data$value.y.breaks
-    i = 1
-    for (h in unique(as.numeric(data$value.y))) {
-      data$value.y.breaks[data$value.y.breaks.temp==h] <-  i
-      i=i+1
-    }
-    data$value.y.breaks.temp <- NULL
-  }
-
-  if (is.null(group)==T) {
-
-    bar <- ggplot() +
-      geom_bar(data=data, aes(x=value.x.breaks, y=value.y.breaks), stat = "identity", fill=gta_colour$blue[1])+
-      scale_y_continuous(breaks = waiver(), labels = waiver(), sec.axis = sec_axis(~.,breaks = waiver(), name = y.axis, labels = waiver()))+
-      scale_x_continuous(breaks = unique(data$value.x.breaks), labels = unique(data$value.x.labels))+
-      ggtitle(title)+
-      labs(x=x.axis, y=y.axis)+
-      gta_theme(x.bottom.angle = 45,
-                x.bottom.align = 1)
-  }
-
-  if (is.null(group)==F) {
-
-    data[,c("group")] <- data[,c(group)]
-    data$group <- factor(data$group)
-
-    eval(parse(text=paste0("col <- round(sqrt((length(unique(agg$'",group,"')))),digits=0)")))
-
-    bar <- ggplot() +
-      geom_bar(data=data, aes(x=value.x.breaks, y=value.y.breaks, fill = group), stat = "identity")+
-      scale_y_continuous(breaks = waiver(), labels = waiver(), sec.axis = sec_axis(~.,breaks = waiver(), name = y.axis, labels = waiver()))+
-      scale_x_continuous(breaks = unique(data$value.x.breaks), labels = unique(data$value.x.labels))+
-      scale_fill_manual(values=colour, labels=unique(data$group))+
-      ggtitle(title)+
-      labs(x=x.axis, y=y.axis)+
-      guides(fill = guide_legend(title=legend.title, ncol = col))+
-      gta_theme(x.bottom.angle = 45,
-                x.bottom.align = 1)
-  }
-
-  gta_plot_saver(plot = bar, path = "17 Shiny/4 data kitchen/results", name = paste("Bar chart from ", Sys.Date(), sep=""), eps=F)
-
-  rm(agg.bar, bar, colour, group, title, legend.title, x.var, y.var, x.axis, y.axis, col)
-}
-
-}},
-error = function(error.msg) {
-  if(error.message[1]==T){
-    error.message <<- c(T, stop.print)
+  
+  
+  if (error.message[1] == T) {
+    error.message <- error.message
   } else {
-    error.message <<- c(T,error.msg$message)
-  }
-})
+    
+    error.message <<- c(F,"")
+    
+    rm(gta.eval,a.flow,ij,aff,a.period,i.period,r.period,s.period,ift,i.types,mast,il,ef,cpc,hs,int.id,lag, a.a.nr)
+    
+    
+    # Helper vector to append values to excel file
+    append.helper <- c(FALSE, TRUE)
+    sheetnames.int <- c("Interventions List", "Interv. List (All)", "Parameter choices", "Param Ch. (All)")
+    sheetnames.counts <- c("Count statistics", "Count statistics (All)", "Parameter choices", "Param Ch. (All)")
+    
+    # Processing of sliced master dataset
+    
+    for (i in 1:length(master)){
+      
+      
+      kl <- kitchen.rows[[i]]
+      master.sliced <- as.data.frame(master[[i]])
+      parameter.choice.slicer <- as.data.frame(p.choices[[i]])
+      
+      if (kl$aggregate.y=="affected.product") {
+        master.sliced <- cSplit(master.sliced, which(colnames(master.sliced)=="affected.product"), direction="long", sep=",")
+      }
+      
+      if (kl$aggregate.y=="affected.sector" | kl$group.cpc == F) {
+        master.sliced <- cSplit(master.sliced, which(colnames(master.sliced)=="affected.sector"), direction="long", sep=",")
+      }
+      
+      if (grepl("gta.evaluation.harmful.liberalising", as.character(kl$aggregate.x))){
+        master.sliced$gta.evaluation[master.sliced$gta.evaluation %in% c("Red","Amber")] = "Harmful"
+        master.sliced$gta.evaluation[master.sliced$gta.evaluation =="Green"] = "Liberalising"
+        names(master.sliced)[names(master.sliced) == 'gta.evaluation'] <- 'gta.evaluation.harmful.liberalising'
+      }
+      
+      
+      if(as.character(kl$aggregate.y)!=""){
+        agg.y=paste(unlist(strsplit(as.character(kl$aggregate.y),",")))}else{agg.y=NULL}
+      
+      if(as.character(kl$aggregate.x)!=""){
+        agg.x=paste(unlist(strsplit(as.character(kl$aggregate.x),",")))
+      }else{
+        stop("Please specify at least one X variable for aggregation.")
+      }
+      
+      # CHECK IF OTHER PARAMETERS SHALL BE GROUPED OR NOT
+      if(kl$group.implementer == F) {
+        agg.x <- append(agg.x, "implementing.jurisdiction")
+      }
+      
+      if(kl$group.affected == F) {
+        agg.x <- append(agg.x, "affected.jurisdiction")
+      }
+      
+      if(kl$group.mast == F) {
+        agg.x <- append(agg.x, "mast.chapter")
+      }
+      
+      if(kl$group.type == F) {
+        agg.x <- append(agg.x, "intervention.type")
+      }
+      
+      if(kl$group.cpc == F) {
+        agg.x <- append(agg.x, "affected.sector")
+      }
+      
+      if(as.character(kl$aggregate.style)!=""){
+        agg.style=paste(unlist(strsplit(as.character(kl$aggregate.style),",")))}else{agg.style=NULL}
+      
+      
+      agg.x <- unique(agg.x)
+      eval(parse(text=paste0("agg <- aggregate(",agg.y," ~ ",paste(agg.x, collapse = "+"), ", master.sliced, function(x) ", agg.style, ")")))
+      
+      agg[is.na(agg)] <- 0
+      
+      # Backup "agg" for later use with plots
+      if(i==1){agg.temp <- agg}
+      
+      if (kl$xlsx == T) {
+        
+        if( (length(agg.x)>1) & TRUE %in% grepl("year", agg.x) ){
+          
+          agg.xlsx=reshape(agg, idvar=agg.x[grepl("year", agg.x)==F], timevar =agg.x[grepl("year", agg.x)==T] , direction="wide")
+          
+          names(agg.xlsx)=gsub(paste(as.character(agg.y),".", sep=""),"", names(agg.xlsx))
+          
+          agg.xlsx[is.na(agg.xlsx)]=0
+          # eval(parse(text=paste0("xlsxList = list('",sheetnames.counts[i],"' = agg.xlsx, '",sheetnames.counts[i+2],"' = parameter.choice.slicer)")))
+          # xlsxList = list(paste0(sheetnames.counts[i]) = agg.xlsx, paste0(sheetnames.counts[i+2]) = parameter.choice.slicer)
+          write.xlsx(x=agg.xlsx, file = paste(path,"results/Count statistics from ", Sys.Date(),".xlsx", sep=""), sheetName = sheetnames.counts[i], row.names = F, append = append.helper[i])
+          write.xlsx(x=parameter.choice.slicer, file = paste(path,"results/Count statistics from ", Sys.Date(),".xlsx", sep=""), sheetName = sheetnames.counts[i+2], append=T, row.names = F)
+          
+          
+        } else{
+          # eval(parse(text=paste0("xlsxList = list('",sheetnames.counts[i],"' = agg, '",sheetnames.counts[i+2],"' = parameter.choice.slicer)")))
+          # xlsxList = list(paste0(sheetnames.counts[i]) = agg, paste0(sheetnames.counts[i+2]) = parameter.choice.slicer)
+          write.xlsx(x=agg, file = paste(path,"results/Count statistics from ", Sys.Date(),".xlsx", sep=""), sheetName = sheetnames.counts[i],row.names = F, append = append.helper[i])
+          write.xlsx(x=parameter.choice.slicer, file = paste(path,"results/Count statistics from ", Sys.Date(),".xlsx", sep=""), sheetName = sheetnames.counts[i+2], append=T, row.names = F)
+          
+          
+        }
+        
+      }
+      
+    }
+    
+    gta_colour_palette()
+    
+    # Retrieve agg from backup
+    agg <- agg.temp
+    
+    # MAP OUTPUT
+    if (kl$map == T) {
+      
+      if(as.character(kl$map.title)!=""){
+        title=paste(unlist(strsplit(as.character(kl$map.title),",")))}else{title=NULL}
+      
+      if(as.character(kl$map.legend.title)!=""){
+        legend.title=paste(unlist(strsplit(as.character(kl$map.legend.title),",")))}else{legend.title=NULL}
+      
+      if(as.character(kl$map.colour.low)!=""){
+        eval(parse(text=paste0("colour.low <- ",kl$map.colour.low)))}else{colour.low=NULL}
+      
+      if(as.character(kl$map.colour.high)!=""){
+        eval(parse(text=paste0("colour.high <- ",kl$map.colour.high)))}else{colour.high=NULL}
+      
+      if(as.character(kl$map.countries)!=""){
+        countries=paste(unlist(strsplit(as.character(kl$map.countries),",")))}else{countries=NULL}
+      
+      if(as.character(kl$map.value)!=""){
+        value=paste(unlist(strsplit(as.character(kl$map.value),",")))}else{value=NULL}
+      
+      if(as.character(kl$map.splits)!=""){
+        range.split=as.numeric(paste(unlist(strsplit(as.character(kl$map.splits),","))))}else{value=waiver()}
+      
+      if(as.character(kl$map.brackets)!=""){
+        range.split=as.numeric(paste(unlist(strsplit(as.character(kl$map.brackets),","))))}
+      
+      
+      
+      eval(parse(text=paste0("data <- aggregate(`",value,"` ~ `",countries,"`, agg, function(x) sum(x))")))
+      
+      map <- gta_plot_map(data = data, countries = countries, value = value, title = title, legend.title = legend.title, colour.high = colour.high, colour.low = colour.low, range.split = range.split)
+      
+      gta_plot_saver(plot = map, path = paste0(path,"results"), name = paste("Map chart from ", Sys.Date(), sep=""), eps=F)
+      
+      rm(map, colour.low, colour.high, value, countries, legend.title)
+      
+    }
+    
+    # TILE CHART OUTPUT
+    if (kl$tile == T) {
+      
+      if(as.character(kl$tile.title)!=""){
+        title=paste(unlist(strsplit(as.character(kl$tile.title),",")))}else{title=NULL}
+      
+      if(as.character(kl$tile.legend.title)!=""){
+        legend.title=paste(unlist(strsplit(as.character(kl$tile.legend.title),",")))}else{legend.title=NULL}
+      
+      if(as.character(kl$tile.x.axis.title)!=""){
+        x.axis=paste(unlist(strsplit(as.character(kl$tile.x.axis.title),",")))}else{x.axis=NULL}
+      
+      if(as.character(kl$tile.y.axis.title)!=""){
+        y.axis=paste(unlist(strsplit(as.character(kl$tile.y.axis.title),",")))}else{y.axis=NULL}
+      
+      if(as.character(kl$tile.colour.low)!=""){
+        eval(parse(text=paste0("colour.low <- ",kl$tile.colour.low)))}else{colour.low=NULL}
+      
+      if(as.character(kl$tile.colour.high)!=""){
+        eval(parse(text=paste0("colour.high <- ",kl$tile.colour.high)))}else{colour.high=NULL}
+      
+      if(as.character(kl$tile.x.var)!=""){
+        x.var=paste(unlist(strsplit(as.character(kl$tile.x.var),",")))}else{x.var=NULL}
+      
+      if(as.character(kl$tile.y.var)!=""){
+        y.var=paste(unlist(strsplit(as.character(kl$tile.y.var),",")))}else{y.var=NULL}
+      
+      if(as.character(kl$tile.value.var)!=""){
+        value=paste(unlist(strsplit(as.character(kl$tile.value.var),",")))}else{value=NULL}
+      
+      eval(parse(text=paste0("data <- aggregate(`",value,"` ~ `",x.var,"`+`",y.var,"`, agg, function(x) sum(x))")))
+      
+      tile <- gta_plot_tile(data = data, value.x = x.var, value.y = y.var, values = value, title = title, legend.title = legend.title, colour.low = colour.low, colour.high = colour.high, y.axis.name = y.axis, x.axis.name = x.axis)
+      
+      gta_plot_saver(plot = tile, path = paste0(path,"results"), name = paste("Tile chart from ", Sys.Date(), sep=""), eps=F)
+      
+      rm(tile, colour.low, colour.high, value, title, legend.title, x.var, y.var, x.axis, y.axis)
+      
+    }
+    
+    
+    # LINE CHART OUTPUT
+    if (kl$line == T) {
+      
+      if(as.character(kl$line.title)!=""){
+        title=paste(unlist(strsplit(as.character(kl$line.title),",")))}else{title=NULL}
+      
+      if(as.character(kl$line.legend.title)!=""){
+        legend.title=paste(unlist(strsplit(as.character(kl$line.legend.title),",")))}else{legend.title=NULL}
+      
+      if(as.character(kl$line.x.axis.title)!=""){
+        x.axis=paste(unlist(strsplit(as.character(kl$line.x.axis.title),",")))}else{x.axis=NULL}
+      
+      if(as.character(kl$line.y.axis.title)!=""){
+        y.axis=paste(unlist(strsplit(as.character(kl$line.y.axis.title),",")))}else{y.axis=NULL}
+      
+      if(as.character(kl$line.x.var)!=""){
+        x.var=paste(unlist(strsplit(as.character(kl$line.x.var),",")))}else{x.var=NULL}
+      
+      if(as.character(kl$line.y.var)!=""){
+        y.var=paste(unlist(strsplit(as.character(kl$line.y.var),",")))}else{y.var=NULL}
+      
+      if(as.character(kl$line.group.var)!=""){
+        group=paste(unlist(strsplit(as.character(kl$line.group.var),",")))}else{group=NULL}
+      
+      if(as.character(kl$line.colour)=="gta_colour$qualitative"){
+        eval(parse(text=paste0("colour <- ",kl$line.colour)))
+        
+      } else if(as.character(kl$line.colour)!="gta_colour$qualitative"){
+        eval(parse(text=paste0("colour <- ",kl$line.colour,"(length(unique(agg$'",group,"')))")))
+        
+      }else{colour=NULL}
+      
+      if (is.null(group)==F) {
+        eval(parse(text=paste0("data <- aggregate(`",y.var,"` ~ `",x.var,"`+`",group,"`, agg, function(x) sum(x))"))) } else {
+          eval(parse(text=paste0("data <- aggregate(`",y.var,"` ~ `",x.var,"`, agg, function(x) sum(x))"))) }
+      
+      data[,c("value.x","value.y")] <- data[,c(x.var, y.var)]
+      
+      data$value.x.labels = data$value.x
+      data$value.y.labels = data$value.y
+      data$value.x.breaks = data$value.x
+      data$value.y.breaks = data$value.y
+      
+      if (is.numeric(data$value.x)==F) {
+        data$value.x.breaks = as.numeric(data$value.x.breaks)
+        data$value.x.breaks.temp <- data$value.x.breaks
+        i = 1
+        for (h in unique(as.numeric(data$value.x))) {
+          data$value.x.breaks[data$value.x.breaks.temp==h] <-  i
+          i=i+1
+        }
+        data$value.x.breaks.temp <- NULL
+      }
+      
+      if (is.numeric(data$value.y)==F) {
+        data$value.y.breaks = as.numeric(data$value.y.breaks)
+        data$value.y.breaks.temp <- data$value.y.breaks
+        i = 1
+        for (h in unique(as.numeric(data$value.y))) {
+          data$value.y.breaks[data$value.y.breaks.temp==h] <-  i
+          i=i+1
+        }
+        data$value.y.breaks.temp <- NULL
+      }
+      
+      if (is.null(group)==T) {
+        
+        line <- ggplot() +
+          geom_line(data=data, aes(x=value.x.breaks, y=value.y.breaks))+
+          scale_y_continuous(breaks = waiver(), labels = waiver(), sec.axis = sec_axis(~.,breaks = waiver(), name = y.axis, labels = waiver()))+
+          scale_x_continuous(breaks = unique(data$value.x.breaks), labels = unique(data$value.x.labels))+
+          ggtitle(title)+
+          labs(x=x.axis, y=y.axis)+
+          gta_theme(x.bottom.angle = 45,
+                    x.bottom.align = 1)
+      }
+      
+      
+      if (is.null(group)==F) {
+        
+        data[,c("group")] <- data[,c(group)]
+        
+        data$group <- factor(data$group)
+        eval(parse(text=paste0("col <- round(sqrt((length(unique(agg$'",group,"')))),digits=0)")))
+        
+        line <- ggplot() +
+          geom_line(data=data, aes(x=value.x.breaks, y=value.y.breaks, colour=group))+
+          scale_y_continuous(breaks = waiver(), labels = waiver(), sec.axis = sec_axis(~.,breaks = waiver(), name = y.axis, labels = waiver()))+
+          scale_x_continuous(breaks = unique(data$value.x.breaks), labels = unique(data$value.x.labels))+
+          scale_colour_manual(values=colour, labels=unique(data$group))+
+          ggtitle(title)+
+          labs(x=x.axis, y=y.axis)+
+          guides(colour = guide_legend(title=legend.title, ncol = col))+
+          gta_theme(x.bottom.angle = 45,
+                    x.bottom.align = 1)
+      }
+      
+      gta_plot_saver(plot = line, path = paste0(path,"results"), name = paste("Line chart from ", Sys.Date(), sep=""), eps=F)
+      
+      rm(agg.line, line, colour, group, title, legend.title, x.var, y.var, x.axis, y.axis, col)
+      
+    }
+    
+    # BAR CHART OUTPUT
+    if (kl$bar == T) {
+      
+      if(as.character(kl$bar.title)!=""){
+        title=paste(unlist(strsplit(as.character(kl$bar.title),",")))}else{title=NULL}
+      
+      if(as.character(kl$bar.legend.title)!=""){
+        legend.title=paste(unlist(strsplit(as.character(kl$bar.legend.title),",")))}else{legend.title=NULL}
+      
+      if(as.character(kl$bar.x.axis.title)!=""){
+        x.axis=paste(unlist(strsplit(as.character(kl$bar.x.axis.title),",")))}else{x.axis=NULL}
+      
+      if(as.character(kl$bar.y.axis.title)!=""){
+        y.axis=paste(unlist(strsplit(as.character(kl$bar.y.axis.title),",")))}else{y.axis=NULL}
+      
+      if(as.character(kl$bar.colour)!=""){
+        eval(parse(text=paste0("colour <- ",kl$bar.colour)))}else{colour=NULL}
+      
+      if(as.character(kl$bar.x.var)!=""){
+        x.var=paste(unlist(strsplit(as.character(kl$bar.x.var),",")))}else{x.var=NULL}
+      
+      if(as.character(kl$bar.y.var)!=""){
+        y.var=paste(unlist(strsplit(as.character(kl$bar.y.var),",")))}else{y.var=NULL}
+      
+      if(as.character(kl$bar.group.var)!=""){
+        group=paste(unlist(strsplit(as.character(kl$bar.group.var),",")))}else{group=NULL}
+      
+      if(as.character(kl$bar.colour)=="gta_colour$qualitative"){
+        eval(parse(text=paste0("colour <- ",kl$bar.colour)))
+        
+      } else if(as.character(kl$bar.colour)!="gta_colour$qualitative"){
+        eval(parse(text=paste0("colour <- ",kl$bar.colour,"(length(unique(agg$'",group,"')))")))
+        
+      }else{colour=NULL}
+      
+      if (is.null(group)==F) {
+        eval(parse(text=paste0("data <- aggregate(`",y.var,"` ~ `",x.var,"`+`",group,"`, agg, function(x) sum(x))"))) } else {
+          eval(parse(text=paste0("data <- aggregate(`",y.var,"` ~ `",x.var,"`, agg, function(x) sum(x))"))) }
+      
+      data[,c("value.x","value.y")] <- data[,c(x.var, y.var)]
+      
+      data$value.x.labels = data$value.x
+      data$value.y.labels = data$value.y
+      data$value.x.breaks = data$value.x
+      data$value.y.breaks = data$value.y
+      
+      if (is.numeric(data$value.x)==F) {
+        data$value.x.breaks = as.numeric(data$value.x.breaks)
+        data$value.x.breaks.temp <- data$value.x.breaks
+        i = 1
+        for (h in unique(as.numeric(data$value.x))) {
+          data$value.x.breaks[data$value.x.breaks.temp==h] <-  i
+          i=i+1
+        }
+        data$value.x.breaks.temp <- NULL
+      }
+      
+      if (is.numeric(data$value.y)==F) {
+        data$value.y.breaks = as.numeric(data$value.y.breaks)
+        data$value.y.breaks.temp <- data$value.y.breaks
+        i = 1
+        for (h in unique(as.numeric(data$value.y))) {
+          data$value.y.breaks[data$value.y.breaks.temp==h] <-  i
+          i=i+1
+        }
+        data$value.y.breaks.temp <- NULL
+      }
+      
+      if (is.null(group)==T) {
+        
+        bar <- ggplot() +
+          geom_bar(data=data, aes(x=value.x.breaks, y=value.y.breaks), stat = "identity", fill=gta_colour$blue[1])+
+          scale_y_continuous(breaks = waiver(), labels = waiver(), sec.axis = sec_axis(~.,breaks = waiver(), name = y.axis, labels = waiver()))+
+          scale_x_continuous(breaks = unique(data$value.x.breaks), labels = unique(data$value.x.labels))+
+          ggtitle(title)+
+          labs(x=x.axis, y=y.axis)+
+          gta_theme(x.bottom.angle = 45,
+                    x.bottom.align = 1)
+      }
+      
+      if (is.null(group)==F) {
+        
+        data[,c("group")] <- data[,c(group)]
+        data$group <- factor(data$group)
+        
+        eval(parse(text=paste0("col <- round(sqrt((length(unique(agg$'",group,"')))),digits=0)")))
+        
+        bar <- ggplot() +
+          geom_bar(data=data, aes(x=value.x.breaks, y=value.y.breaks, fill = group), stat = "identity")+
+          scale_y_continuous(breaks = waiver(), labels = waiver(), sec.axis = sec_axis(~.,breaks = waiver(), name = y.axis, labels = waiver()))+
+          scale_x_continuous(breaks = unique(data$value.x.breaks), labels = unique(data$value.x.labels))+
+          scale_fill_manual(values=colour, labels=unique(data$group))+
+          ggtitle(title)+
+          labs(x=x.axis, y=y.axis)+
+          guides(fill = guide_legend(title=legend.title, ncol = col))+
+          gta_theme(x.bottom.angle = 45,
+                    x.bottom.align = 1)
+      }
+      
+      gta_plot_saver(plot = bar, path = paste0(path,"results"), name = paste("Bar chart from ", Sys.Date(), sep=""), eps=F)
+      
+      rm(agg.bar, bar, colour, group, title, legend.title, x.var, y.var, x.axis, y.axis, col)
+    }
+    
+  }},
+  error = function(error.msg) {
+    if(error.message[1]==T){
+      error.message <<- c(T, stop.print)
+    } else {
+      error.message <<- c(T,error.msg$message)
+    }
+  })
 
 # rm(master.sliced, parameter.choice.slicer, gta_colour)

--- a/code/order processing/GTA data kitchen order - trade coverage.R
+++ b/code/order processing/GTA data kitchen order - trade coverage.R
@@ -1,195 +1,392 @@
 # UNCOMMENT FOR TESTING
 
-library(xlsx)
-
+# library(openxlsx)
+# library(gtalibrary)
 # setwd("/Users/patrickbuess/Dropbox/Collaborations/GTA cloud")
 # load("0 dev/data-kitchen-pb/log/kitchen log.Rdata")
 # kl = kitchen.log[nrow(kitchen.log),]
 
+library(openxlsx)
+
 # PROCESSING
 
+# path = "17 Shiny/4 data kitchen/"
+path = "0 dev/data-kitchen-pb/"
+
 tryCatch({
-
-if(as.character(kl$coverage.period)!=""){
-  c.period=as.numeric(paste(unlist(strsplit(as.character(kl$coverage.period),","))))}else{c.period=NULL}
-
-if(as.character(kl$gta.evaluation)!=""){
-  gta.eval=paste(unlist(strsplit(as.character(kl$gta.evaluation),",")))}else{gta.eval=NULL}
-
-if(as.character(kl$affected.flows)!=""){
-  a.flow=paste(unlist(strsplit(as.character(kl$affected.flows),",")))}else{a.flow=NULL}
-
-if(as.character(kl$importers)!=""){
-  imps=paste(unlist(strsplit(as.character(kl$importers),",")))
-  if("" %in% imps){imps = imps[!imps==""]}}else{imps=NULL}
-
-if(as.character(kl$incl.importers.strictness)!=""){
-  incl.imp.str=paste(unlist(strsplit(as.character(kl$incl.importers.strictness),",")))}else{incl.imp.str=NULL}
   
-if(as.character(kl$nr.importers)!=""){
-  nr.imp=as.numeric(paste(unlist(strsplit(as.character(kl$nr.importers),","))))
-  nr.imp <- nr.imp[is.na(nr.imp)==F]}else{nr.imp=c(0,999)}
-
-if(as.character(kl$nr.importers.incl)!=""){
-  nr.imp.incl=paste(unlist(strsplit(as.character(kl$nr.importers.incl),",")))}else{nr.imp.incl=NULL}
+  if(as.character(kl$coverage.period)!=""){
+    c.period=as.numeric(paste(unlist(strsplit(as.character(kl$coverage.period),","))))}else{c.period=NULL}
   
-if(as.character(kl$exporters)!=""){
-  exps=paste(unlist(strsplit(as.character(kl$exporters),",")))
-  if("" %in% exps){exps = exps[!exps==""]}}else{exps=NULL}
-
-if(as.character(kl$incl.exporters.strictness)!=""){
-  incl.exp.str=paste(unlist(strsplit(as.character(kl$incl.exporters.strictness),",")))}else{incl.exp.str=NULL}
-
-if(as.character(kl$nr.exporters)!=""){
-  nr.exp=as.numeric(paste(unlist(strsplit(as.character(kl$nr.exporters),","))))
-  nr.exp <- nr.exp[is.na(nr.exp)==F]}else{nr.exp=c(0,999)}
-
-if(as.character(kl$nr.exporters.incl)!=""){
-  nr.exp.incl=paste(unlist(strsplit(as.character(kl$nr.exporters.incl),",")))}else{nr.exp.incl=NULL}
+  if(as.character(kl$gta.evaluation)!=""){
+    gta.eval=paste(unlist(strsplit(as.character(kl$gta.evaluation),",")))}else{gta.eval=NULL}
   
-if(as.character(kl$implementers)!=""){
-  ij=paste(unlist(strsplit(as.character(kl$implementers),",")))
-  ij <- ij[ij != ""]}else{ij=NULL}
-
-if(as.character(kl$implementer.role)!="NA,NA"){
-  ij.role=paste(unlist(strsplit(as.character(kl$implementer.role),",")))}else{ij.role=NULL}
-
-if(as.character(kl$announcement.period)!="NA,NA"){
-  a.period=paste(unlist(strsplit(as.character(kl$announcement.period),",")))
-  a.period[a.period=="NA"] <- NA
-}else{a.period=NULL}
-
-if(as.character(kl$implementation.period)!="NA,NA"){
-  i.period=paste(unlist(strsplit(as.character(kl$implementation.period),",")))
-  i.period[i.period=="NA"] <- NA
-}else{i.period=NULL}
-
-if(as.character(kl$revocation.period)!="NA,NA"){
-  r.period=paste(unlist(strsplit(as.character(kl$revocation.period),",")))
-  r.period[r.period=="NA"] <- NA
-}else{r.period=NULL}
-
-if(as.character(kl$in.force.today)!=""){
-  ift=paste(unlist(strsplit(as.character(kl$in.force.today),",")))}else{ift=NULL}
-
-if(as.character(kl$intervention.types)!=""){
-  i.types=paste(unlist(strsplit(as.character(kl$intervention.types),",")))
-  nes.list <- c("Import-related non-tariff measure","Export-related non-tariff measure","Public procurement","State aid","FDI: Treatment and operations")
-  if("" %in% i.types){i.types = i.types[!i.types==""]}
-  if (any(i.types %in% nes.list)){
-    for (i in 1:length(i.types)){
-      if (i.types[i] %in% nes.list){i.types[i] <- paste0(i.types[i],", nes")}
-      if (i.types[i] ==" nes"){i.types[i] <- 0}}
-    i.types <- i.types[i.types!=0]
-  }}else{i.types=NULL}
-
-if(as.character(kl$mast.chapters)!=""){
-  mast=paste(unlist(strsplit(as.character(kl$mast.chapters),",")))
-  if("" %in% mast){mast = mast[!mast==""]}}else{mast=NULL}
-
-if(! grepl("any", as.character(kl$implementation.level))){
-  il=paste(unlist(strsplit(as.character(kl$implementation.level),",")))}else{il=NULL}
-
-if(! grepl("any", as.character(kl$eligible.firms))){
-  ef=paste(unlist(strsplit(as.character(kl$eligible.firms),",")))
-  if("" %in% ef){ef = ef[!ef==""]}}else{ef=NULL}
-
-if(as.character(kl$cpc.sectors)!=""){
-  cpc=as.numeric(paste(unlist(strsplit(as.character(kl$cpc.sectors),","))))
-  if("" %in% cpc){cpc = cpc[!cpc==""]}}else{cpc=NULL}
-
-if(as.character(kl$hs.codes)!=""){
-  hs=as.numeric(paste(unlist(strsplit(as.character(kl$hs.codes),","))))
-  if("" %in% hs){hs = hs[!hs==""]}}else{hs=NULL}
-
-if(as.character(kl$intervention.ids)!=""){
-  int.id=paste(unlist(strsplit(as.character(kl$intervention.ids),",")))}else{int.id=NULL}
-
-if(as.character(kl$lag.adjustment)!=""){
-  lag=paste(paste(unlist(strsplit(as.character(kl$lag.adjustment),"-")))[2],
-            paste(unlist(strsplit(as.character(kl$lag.adjustment),"-")))[3],sep="-")}else{lag=NULL}
-
-
-if(as.character(kl$choose.output)!=""){
-  trade.statistic=as.character(kl$choose.output)}else{trade.statistic="share"}
-
-if(as.character(kl$choose.tradebase)!=""){
-  trade.data=as.character(kl$choose.tradebase)}else{trade.data="base"}
-
-if(as.character(kl$hit.brackets)!=""){
-  hb=paste(unlist(strsplit(as.character(kl$hit.brackets),",")))}else{hb=c(1,99999)}
-
-
-
-## running the function
-gta_trade_coverage(
-  data.path="data/master_plus.Rdata",
-  replica.path="data/database replica/database replica - parts - base.Rdata",
-  coverage.period=c.period,
-  current.year.todate=kl$current.year.todate==T,
-  gta.evaluation= gta.eval,
-  affected.flows = a.flow,
-  importers = imps,
-  group.importers = kl$group.importers==T,
-  keep.importers = kl$keep.importers==T,
-  incl.importers.strictness = incl.imp.str,
-  separate.importer.groups = kl$separate.importer.groups==T,
-  nr.importers = nr.imp, 
-  nr.importers.incl = nr.imp.incl,
-  exporters = exps,
-  group.exporters = kl$group.exporters==T,
-  keep.exporters = kl$keep.exporters==T,
-  incl.exporters.strictness = incl.exp.str,
-  separate.exporter.groups = kl$separate.exporter.groups==T,
-  nr.exporters = nr.exp, 
-  nr.exporters.incl = nr.exp.incl,
-  implementers = ij,
-  implementer.role = ij.role,
-  keep.implementer = kl$keep.implementer==T,
-  announcement.period = a.period,
-  implementation.period = i.period,
-  revocation.period = r.period,
-  in.force.today = ift,
-  intervention.types = i.types,
-  keep.type = kl$keep.type==T,
-  group.type=kl$group.type==T,
-  mast.chapters = mast,
-  keep.mast = kl$keep.mast==T,
-  group.mast=kl$group.mast==T,
-  implementation.level = il,
-  keep.level = kl$keep.level==T,
-  eligible.firms = ef,
-  keep.firms = kl$keep.firms==T,
-  cpc.sectors = cpc,
-  keep.cpc = kl$keep.cpc==T,
-  hs.codes = hs,
-  keep.hs = kl$keep.hs==T,
-  hit.brackets = hb,
-  intervention.ids = int.id,
-  keep.interventions = kl$keep.interventions==T,
-  lag.adjustment=lag,
-  trade.statistic=trade.statistic,
-  trade.data=trade.data,
-  intra.year.duration = kl$adjust.for.intra==T,
-  rdata = FALSE,
-  xlsx = TRUE,
-  output.path = paste("17 Shiny/4 data kitchen/results/",Sys.Date()," - GTA data dish #",kl$ticket.number,".xlsx",sep="")
-)
-
-
-rm(c.period,gta.eval,a.flow,imps,nr.imp,nr.imp.incl,incl.imp.str,exps,nr.exp,nr.exp.incl,incl.exp.str,ij,ij.role,a.period,i.period,r.period,ift,i.types,mast,il,ef,cpc,hs,int.id,lag)
-rm(kl, trade.coverage.estimates, bilateral.trade,parameter.choices)
-
-if (error.message[1] == T) {
-  error.message <- error.message
-} else {
-  error.message <- c(F,"")
-}},
-
-error = function(error.msg) {
-  if(error.message[1]==T){
-    error.message <<- c(T, stop.print)
-  } else {
-    error.message <<- c(T,error.msg$message)
+  if(as.character(kl$affected.flows)!=""){
+    a.flow=paste(unlist(strsplit(as.character(kl$affected.flows),",")))}else{a.flow=NULL}
+  
+  if(as.character(kl$importers)!=""){
+    imps=paste(unlist(strsplit(as.character(kl$importers),",")))
+    if("" %in% imps){imps = imps[!imps==""]}}else{imps=NULL}
+  
+  if(as.character(kl$incl.importers.strictness)!=""){
+    incl.imp.str=paste(unlist(strsplit(as.character(kl$incl.importers.strictness),",")))}else{incl.imp.str=NULL}
+  
+  if(as.character(kl$nr.importers)!=""){
+    nr.imp=as.numeric(paste(unlist(strsplit(as.character(kl$nr.importers),","))))
+    nr.imp <- nr.imp[is.na(nr.imp)==F]}else{nr.imp=c(0,999)}
+  
+  if(as.character(kl$nr.importers.incl)!=""){
+    nr.imp.incl=paste(unlist(strsplit(as.character(kl$nr.importers.incl),",")))}else{nr.imp.incl=NULL}
+  
+  if(as.character(kl$exporters)!=""){
+    exps=paste(unlist(strsplit(as.character(kl$exporters),",")))
+    if("" %in% exps){exps = exps[!exps==""]}}else{exps=NULL}
+  
+  if(as.character(kl$incl.exporters.strictness)!=""){
+    incl.exp.str=paste(unlist(strsplit(as.character(kl$incl.exporters.strictness),",")))}else{incl.exp.str=NULL}
+  
+  if(as.character(kl$nr.exporters)!=""){
+    nr.exp=as.numeric(paste(unlist(strsplit(as.character(kl$nr.exporters),","))))
+    nr.exp <- nr.exp[is.na(nr.exp)==F]}else{nr.exp=c(0,999)}
+  
+  if(as.character(kl$nr.exporters.incl)!=""){
+    nr.exp.incl=paste(unlist(strsplit(as.character(kl$nr.exporters.incl),",")))}else{nr.exp.incl=NULL}
+  
+  if(as.character(kl$implementers)!=""){
+    ij=paste(unlist(strsplit(as.character(kl$implementers),",")))
+    ij <- ij[ij != ""]}else{ij=NULL}
+  
+  if(as.character(kl$implementer.role)!="NA,NA"){
+    ij.role=paste(unlist(strsplit(as.character(kl$implementer.role),",")))}else{ij.role=NULL}
+  
+  if(as.character(kl$announcement.period)!="NA,NA"){
+    a.period=paste(unlist(strsplit(as.character(kl$announcement.period),",")))
+    a.period[a.period=="NA"] <- NA
+  }else{a.period=NULL}
+  
+  if(as.character(kl$implementation.period)!="NA,NA"){
+    i.period=paste(unlist(strsplit(as.character(kl$implementation.period),",")))
+    i.period[i.period=="NA"] <- NA
+  }else{i.period=NULL}
+  
+  if(as.character(kl$revocation.period)!="NA,NA"){
+    r.period=paste(unlist(strsplit(as.character(kl$revocation.period),",")))
+    r.period[r.period=="NA"] <- NA
+  }else{r.period=NULL}
+  
+  if(as.character(kl$submission.period)!="NA,NA"){
+    s.period=paste(unlist(strsplit(as.character(kl$submission.period),",")))
+    s.period[s.period=="NA"] <- NA
+  }else{s.period=NULL}
+  
+  if(as.character(kl$in.force.today)!=""){
+    ift=paste(unlist(strsplit(as.character(kl$in.force.today),",")))}else{ift=NULL}
+  
+  if(as.character(kl$intervention.types)!=""){
+    i.types=paste(unlist(strsplit(as.character(kl$intervention.types),",")))
+    nes.list <- c("Import-related non-tariff measure","Export-related non-tariff measure","Public procurement","State aid","FDI: Treatment and operations")
+    if("" %in% i.types){i.types = i.types[!i.types==""]}
+    if (any(i.types %in% nes.list)){
+      for (i in 1:length(i.types)){
+        if (i.types[i] %in% nes.list){i.types[i] <- paste0(i.types[i],", nes")}
+        if (i.types[i] ==" nes"){i.types[i] <- 0}}
+      i.types <- i.types[i.types!=0]
+    }}else{i.types=NULL}
+  
+  if(as.character(kl$mast.chapters)!=""){
+    mast=paste(unlist(strsplit(as.character(kl$mast.chapters),",")))
+    if("" %in% mast){mast = mast[!mast==""]}}else{mast=NULL}
+  
+  if(! grepl("any", as.character(kl$implementation.level))){
+    il=paste(unlist(strsplit(as.character(kl$implementation.level),",")))}else{il=NULL}
+  
+  if(! grepl("any", as.character(kl$eligible.firms))){
+    ef=paste(unlist(strsplit(as.character(kl$eligible.firms),",")))
+    if("" %in% ef){ef = ef[!ef==""]}}else{ef=NULL}
+  
+  # CHECK WHETHER ALL SERVICE OR ALL GOODS ARE CHOSEN
+  if (any(c("all_service","all_goods") %in% unlist(strsplit(as.character(kl$cpc.sectors),",")))) {
+    if ("all_service" %in% unlist(strsplit(as.character(kl$cpc.sectors),","))) {
+      cpc_new <- subset(gtalibrary::cpc.names, cpc > 499 & cpc.digit.level == 3)$cpc
+      temp <- unlist(strsplit(as.character(kl$cpc.sectors),","))
+      temp <- temp[temp != "all_service"]
+      temp <- append(temp, cpc_new)
+      kl$cpc.sectors <- paste(temp, collapse = ",")
+      rm(temp)
+    }
+    if ("all_goods" %in% unlist(strsplit(as.character(kl$cpc.sectors),","))) {
+      cpc_new <- subset(gtalibrary::cpc.names, cpc < 500 & cpc.digit.level == 3)$cpc
+      temp <- unlist(strsplit(as.character(kl$cpc.sectors),","))
+      temp <- temp[temp != "all_goods"]
+      temp <- append(temp, cpc_new)
+      kl$cpc.sectors <- paste(temp, collapse = ",")
+      rm(temp)
+    }
   }
-})
+  
+  # CHECK IF PRODUCT GROUPS ARE CHOSEN FOR CPC
+  product.groups <- gtalibrary::hs.codes
+  product.groups <- names(product.groups)
+  product.groups <- product.groups[grepl("is.", product.groups)]
+  product.groups <- gsub("is.","",product.groups)
+  product.groups <- gsub("\\."," ",product.groups)
+  
+  if (any(tolower(c(product.groups)) %in% tolower(unlist(strsplit(as.character(kl$cpc.sectors),","))))) {
+    groups <- product.groups[tolower(product.groups) %in% tolower(unlist(strsplit(as.character(kl$cpc.sectors),",")))]
+    groups <- paste0("is.", tolower(gsub(" ","\\.",groups)))
+    cpc_new <- c()
+    for (i in groups) {
+      eval(parse(text = paste0("temp <- subset(gtalibrary::hs.codes, ",i,"==T)$hs.code")))
+      temp <- gta_hs_to_cpc(temp)
+      temp <- unique(as.numeric(substr(temp, 1,3)))
+      cpc_new <- c(cpc_new, temp)
+    }
+    temp <- unique(unlist(strsplit(as.character(kl$cpc.sectors),",")))
+    temp <- unique(c(temp, cpc_new))
+    kl$cpc.sectors <- paste(temp[! tolower(temp) %in% tolower(product.groups)], collapse=",")
+  }
+  
+  if(as.character(kl$cpc.sectors)!=""){
+    cpc=paste(unlist(strsplit(as.character(kl$cpc.sectors),",")))
+    cpc <- cpc[is.na(cpc)==F]}else{cpc=NULL}
+  
+  
+  # CHECK WHETHER PRODUCT GROUPS ARE IN HS CODES
+  if (any(tolower(c(product.groups)) %in% tolower(unlist(strsplit(as.character(kl$hs.codes),","))))) {
+    groups <- product.groups[tolower(product.groups) %in% tolower(unlist(strsplit(as.character(kl$hs.codes),",")))]
+    groups <- paste0("is.", tolower(gsub(" ","\\.",groups)))
+    hs_new <- c()
+    for (i in groups) {
+      eval(parse(text = paste0("temp <- subset(gtalibrary::hs.codes, ",i,"==T)$hs.code")))
+      temp <- gta_hs_code_check(temp)
+      hs_new <- c(hs_new, temp)
+    }
+    temp <- unique(unlist(strsplit(as.character(kl$hs.codes),",")))
+    temp <- unique(c(temp, hs_new))
+    kl$hs.codes <- paste(temp[! tolower(temp) %in% tolower(product.groups)], collapse=",")
+  }
+  
+  if(as.character(kl$hs.codes)!=""){
+    hs=paste(unlist(strsplit(as.character(kl$hs.codes),",")))
+    hs <- hs[is.na(hs)==F]}else{hs=NULL}
+  
+  if(as.character(kl$intervention.ids)!=""){
+    int.id=paste(unlist(strsplit(as.character(kl$intervention.ids),",")))}else{int.id=NULL}
+  
+  if(as.character(kl$lag.adjustment)!=""){
+    lag=paste(paste(unlist(strsplit(as.character(kl$lag.adjustment),"-")))[2],
+              paste(unlist(strsplit(as.character(kl$lag.adjustment),"-")))[3],sep="-")}else{lag=NULL}
+  
+  
+  if(as.character(kl$choose.output)!=""){
+    trade.statistic=as.character(kl$choose.output)}else{trade.statistic="share"}
+  
+  if(as.character(kl$choose.tradebase)!=""){
+    trade.data=as.character(kl$choose.tradebase)}else{trade.data="base"}
+  
+  if(as.character(kl$hit.brackets)!=""){
+    hb=paste(unlist(strsplit(as.character(kl$hit.brackets),",")))}else{hb=c(1,99999)}
+  
+  
+  
+  # CHECK IF "ALL" VALUE IS INCLUDED ANYWHERE
+  # THESE WILL BE CALCULATED SEPARATELY IN A SECOND LOOP
+  additional.all <- c()
+  
+  types = list("imps" = imps,
+               "exps" = exps,
+               "ij" = ij,
+               "cpc" = cpc,
+               "hs" = hs,
+               "mast" = mast,
+               "i.types" = i.types)
+  
+  for (i in 1:length(types)) {
+    if(length(types[[i]]) == 1 & types[[i]] == "all") {
+      eval(parse(text=paste0(names(types[i]),"= NULL")))  
+    } else if ("all" %in% types[[i]]) {
+      additional.all <- c(additional.all, names(types[i]))
+      eval(parse(text=paste0(names(types[i]),"=",names(types[i]),"[",names(types[i]),"!= 'all']")))
+    }  
+  }
+  
+  # CONVERT HS AND CPC TO NUMERIC IF NECESSARY
+  if (is.null(hs)==F){hs <- as.numeric(hs)}
+  if (is.null(cpc)==F){cpc <- as.numeric(cpc)}
+  
+  ## running the function
+  gta_trade_coverage(
+    data.path="data/master_plus.Rdata",
+    replica.path="data/database replica/database replica - parts - base.Rdata",
+    coverage.period=c.period,
+    current.year.todate=kl$current.year.todate==T,
+    gta.evaluation= gta.eval,
+    affected.flows = a.flow,
+    importers = imps,
+    group.importers = kl$group.importers==T,
+    keep.importers = kl$keep.importers==T,
+    incl.importers.strictness = incl.imp.str,
+    separate.importer.groups = kl$separate.importer.groups==T,
+    nr.importers = nr.imp, 
+    nr.importers.incl = nr.imp.incl,
+    exporters = exps,
+    group.exporters = kl$group.exporters==T,
+    keep.exporters = kl$keep.exporters==T,
+    incl.exporters.strictness = incl.exp.str,
+    separate.exporter.groups = kl$separate.exporter.groups==T,
+    nr.exporters = nr.exp, 
+    nr.exporters.incl = nr.exp.incl,
+    implementers = ij,
+    implementer.role = ij.role,
+    keep.implementer = kl$keep.implementer==T,
+    announcement.period = a.period,
+    implementation.period = i.period,
+    revocation.period = r.period,
+    keep.revocation.na = kl$keep.revocation.na==T,
+    submission.period = s.period,
+    in.force.today = ift,
+    intervention.types = i.types,
+    keep.type = kl$keep.type==T,
+    group.type=kl$group.type==T,
+    mast.chapters = mast,
+    keep.mast = kl$keep.mast==T,
+    group.mast=kl$group.mast==T,
+    implementation.level = il,
+    keep.level = kl$keep.level==T,
+    eligible.firms = ef,
+    keep.firms = kl$keep.firms==T,
+    cpc.sectors = cpc,
+    keep.cpc = kl$keep.cpc==T,
+    hs.codes = hs,
+    keep.hs = kl$keep.hs==T,
+    hit.brackets = hb,
+    intervention.ids = int.id,
+    keep.interventions = kl$keep.interventions==T,
+    lag.adjustment=lag,
+    trade.statistic=trade.statistic,
+    trade.data=trade.data,
+    intra.year.duration = kl$adjust.for.intra==T,
+    rdata = FALSE,
+    xlsx = FALSE,
+    output.path = paste(path,"results/",Sys.Date()," - GTA data dish #",kl$ticket.number,".xlsx",sep=""),
+    xlsx.interventions = kl$xlsx.interventions==T,
+    output.path.interventions = paste(path,"results/",Sys.Date()," - GTA data dish #",kl$ticket.number," - interventions.xlsx",sep="")
+  )
+  
+  results <- trade.coverage.estimates
+  pm.choices <- parameter.choices
+  
+  # CALCULATE ALL VALUES IF NECESSARY
+  if(length(additional.all)>0) {
+    
+    types = list(c("imps", "group.importers","Importers"),
+                 c("exps", "group.exporters","Exporters"),
+                 c("ij", "group.implementers","Implementers"),
+                 c("cpc", "group.cpc","CPC Sectors"),
+                 c("hs", "group.hs","HS Codes"),
+                 c("mast", "group.mast","MAST Chapters"),
+                 c("i.types", "group.types","Intervention types"))
+    
+    for (i in 1:length(types)) {
+      if(types[[i]][1] %in% additional.all) {
+        eval(parse(text=paste0(types[[i]][1],"= NULL")))
+        eval(parse(text=paste0("kl$",types[[i]][2],"= TRUE")))
+      }
+    }
+    
+    ## running the function
+    gta_trade_coverage(
+      data.path="data/master_plus.Rdata",
+      replica.path="data/database replica/database replica - parts - base.Rdata",
+      coverage.period=c.period,
+      current.year.todate=kl$current.year.todate==T,
+      gta.evaluation= gta.eval,
+      affected.flows = a.flow,
+      importers = imps,
+      group.importers = kl$group.importers==T,
+      keep.importers = kl$keep.importers==T,
+      incl.importers.strictness = incl.imp.str,
+      separate.importer.groups = kl$separate.importer.groups==T,
+      nr.importers = nr.imp, 
+      nr.importers.incl = nr.imp.incl,
+      exporters = exps,
+      group.exporters = kl$group.exporters==T,
+      keep.exporters = kl$keep.exporters==T,
+      incl.exporters.strictness = incl.exp.str,
+      separate.exporter.groups = kl$separate.exporter.groups==T,
+      nr.exporters = nr.exp, 
+      nr.exporters.incl = nr.exp.incl,
+      implementers = ij,
+      implementer.role = ij.role,
+      keep.implementer = kl$keep.implementer==T,
+      announcement.period = a.period,
+      implementation.period = i.period,
+      revocation.period = r.period,
+      keep.revocation.na = kl$keep.revocation.na==T,
+      submission.period = s.period,
+      in.force.today = ift,
+      intervention.types = i.types,
+      keep.type = kl$keep.type==T,
+      group.type=kl$group.type==T,
+      mast.chapters = mast,
+      keep.mast = kl$keep.mast==T,
+      group.mast=kl$group.mast==T,
+      implementation.level = il,
+      keep.level = kl$keep.level==T,
+      eligible.firms = ef,
+      keep.firms = kl$keep.firms==T,
+      cpc.sectors = cpc,
+      keep.cpc = kl$keep.cpc==T,
+      hs.codes = hs,
+      keep.hs = kl$keep.hs==T,
+      hit.brackets = hb,
+      intervention.ids = int.id,
+      keep.interventions = kl$keep.interventions==T,
+      lag.adjustment=lag,
+      trade.statistic=trade.statistic,
+      trade.data=trade.data,
+      intra.year.duration = kl$adjust.for.intra==T,
+      rdata = FALSE,
+      xlsx = FALSE,
+      output.path = paste(path,"results/",Sys.Date()," - GTA data dish #",kl$ticket.number,".xlsx",sep="")
+    )
+    
+    results.2 <- trade.coverage.estimates
+    pm.choices.2 <- parameter.choices
+    
+    for (i in 1:length(types)) {
+      if(types[[i]][1] %in% additional.all) {
+        eval(parse(text=paste0("results.2$`",types[[i]][3],"` = 'All ",types[[i]][3],"'")))
+        eval(parse(text=paste0("results$`",types[[i]][3],"` = 'Selected ",types[[i]][3],"'")))
+      }
+    }
+    
+    results <- rbind(results, results.2)
+    rm(results.2)
+  }
+  
+  # SAVE EXCEL
+  xlsxList <- list("Coverages"=results,"Parameter choices"=pm.choices)
+  if(exists("pm.choices.2")){
+    xlsxList[["Parameter choices (All)"]] <- pm.choices.2
+  }
+  
+  openxlsx::write.xlsx(xlsxList, file=paste(path,"results/",Sys.Date()," - GTA data dish #",kl$ticket.number,".xlsx",sep=""), rowNames = F)
+  
+  rm(c.period,gta.eval,a.flow,imps,nr.imp,nr.imp.incl,incl.imp.str,exps,nr.exp,nr.exp.incl,incl.exp.str,ij,ij.role,a.period,i.period,r.period,ift,i.types,mast,il,ef,cpc,hs,int.id,lag)
+  rm(kl, trade.coverage.estimates, bilateral.trade,parameter.choices)
+  
+  
+  if (error.message[1] == T) {
+    error.message <- error.message
+  } else {
+    error.message <- c(F,"")
+  }},
+  
+  error = function(error.msg) {
+    if(error.message[1]==T){
+      error.message <<- c(T, stop.print)
+    } else {
+      error.message <<- c(T,error.msg$message)
+    }
+  })


### PR DESCRIPTION
- Added path as a variable for easier switching
- made layout changes to the shiny app
- Added product groups from hs.codes df (shiny app: line 51)
- Added "All" as explicit values
- Added keep.revocation.na checkbox
- Added interventions.list output to coverages

CHEF DE CUISINE:
- Added path as variable
- Added optional output of interventions list (line: 140)
- Commented out renaming of coverage files (does not seem necessary anymore, as files are originally generated with the right name already)

UPDATE FILES:
- Added new default values
- Fixed mistake in variable name

ORDER PROCESSING - DATA COUNTS
- Added path as variable
- Added product groups hook (line 106 ff)
- Added hook for "all" values, which makes a list of variables which must be recalculated in a second turn (line 160)
- Added second function, to recalculate "all" values (line 239)
- Wrapped processing of excel aggregate file in a loop, if it has to run 2 times
- Added new parameters to map function

PROCESSING FILE COVERAGES
- Added path as variable
- Added hook for product groups (line 127)
- Added hook for "all" values (line 192)
- Added second function to catch "all" values (line 279)